### PR TITLE
A quick fix example to demonstrate how to replace alias with local name

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/src/com/ge/research/sadl/ide/editor/contentassist/ProposalProviderValidationAcceptor.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/src/com/ge/research/sadl/ide/editor/contentassist/ProposalProviderValidationAcceptor.xtend
@@ -48,7 +48,7 @@ class ProposalProviderValidationAcceptor implements ValidationAcceptor, Predicat
 		];
 	}
 
-	override add(String message, EObject context, Severity severity) {
+	override add(String message, EObject context, Severity severity, String issueCode, String... issueData) {
 		issues.get(severity).put(context, message);
 	}
 

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
@@ -9426,8 +9426,12 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 	}
 	
 	public void addError(String msg, EObject context) {
+		addError(msg, context, null);
+	}
+
+	public void addError(String msg, EObject context, String issueCode, String... issueData) {
 		if (getIssueAcceptor() != null) {
-			getIssueAcceptor().addError(msg, context);
+			getIssueAcceptor().add(msg, context, Severity.ERROR, issueCode, issueData);
 			if (isSyntheticUri(null, getCurrentResource())) {
 				if (getMetricsProcessor() != null) {
 					getMetricsProcessor().addMarker(null, MetricsProcessor.ERROR_MARKER_URI,
@@ -9440,8 +9444,12 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 	}
 
 	public void addWarning(String msg, EObject context) {
+		addWarning(msg, context, null);
+	}
+
+	public void addWarning(String msg, EObject context, String issueCode, String... issueData) {
 		if (getIssueAcceptor() != null) {
-			getIssueAcceptor().addWarning(msg, context);
+			getIssueAcceptor().add(msg, context, Severity.WARNING, issueCode, issueData);
 			if (isSyntheticUri(null, getCurrentResource())) {
 				if (getMetricsProcessor() != null) {
 					getMetricsProcessor().addMarker(null, MetricsProcessor.WARNING_MARKER_URI,
@@ -9454,8 +9462,12 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 	}
 
 	public void addInfo(String msg, EObject context) {
+		addInfo(msg, context, null);
+	}
+
+	public void addInfo(String msg, EObject context, String issueCode, String... issueData) {
 		if (getIssueAcceptor() != null) {
-			getIssueAcceptor().addInfo(msg, context);
+			getIssueAcceptor().add(msg, context, Severity.INFO, issueCode, issueData);
 			if (isSyntheticUri(null, getCurrentResource())) {
 				if (getMetricsProcessor() != null) {
 					getMetricsProcessor().addMarker(null, MetricsProcessor.INFO_MARKER_URI,
@@ -10122,7 +10134,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 						StmtIterator stmtitr = getTheJenaModel().listStatements(null, RDFS.label, lit);
 						while (stmtitr.hasNext()) {
 							com.hp.hpl.jena.rdf.model.Resource replacement = stmtitr.nextStatement().getSubject();
-							addWarning("Consider replacing '" + txt + "' with '" + replacement.getLocalName() + "'", contr);
+							addWarning("Consider replacing '" + txt + "' with '" + replacement.getLocalName() + "'", contr, "REPLACE_ALIAS", replacement.getLocalName());
 						}
 					}
 			    	String psrc = getSourceText(prop);

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/quickfix/SADLQuickfixProvider.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/quickfix/SADLQuickfixProvider.xtend
@@ -64,6 +64,21 @@ class SADLQuickfixProvider extends DefaultQuickfixProvider {
 	
 	@Inject
 	IURIEditorOpener editorOpener;
+	
+	@Fix("REPLACE_ALIAS")
+	def void replaceAlias(Issue issue, IssueResolutionAcceptor acceptor) {
+		val data = issue.data
+		if (data !== null && data.size === 1) {
+			val replacement = data.get(0)
+			if (!replacement.nullOrEmpty) {
+				val label = "Change to '" + replacement + "'"
+				acceptor.accept(issue, label, label, null, [ context |
+					val xtextDocument = context.xtextDocument
+					xtextDocument.replace(issue.offset, issue.length, replacement)
+				])
+			}
+		}
+	}
 
 	@Fix(AmbiguousNameErrorEObjectDescription.AMBIGUOUS_NAME_ISSUE_CODE)
 	def fixAmbigupusNames(Issue issue, IssueResolutionAcceptor acceptor) {

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/processing/ValidationAcceptor.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/processing/ValidationAcceptor.xtend
@@ -28,31 +28,34 @@ import static org.eclipse.xtext.diagnostics.Severity.*
  * @author akos.kitta
  */
 interface ValidationAcceptor {
-	
+
 	/**
 	 * Shared NOOP validation acceptor.
 	 */
 	val NOOP = new ValidationAcceptor() {
-		
-		@Override
-		override add(String message, EObject context, Severity severity) {
+
+		override add(String message, EObject context, Severity severity, String issueCode, String... issueData) {
 			// NOOP
 		}
-		
+
 	}
-	
+
 	def void addInfo(String message, EObject context) {
-		add(message, context, INFO)
+		add(message, context, INFO, null)
 	}
-	
+
 	def void addError(String message, EObject context) {
-		add(message, context, ERROR)
+		add(message, context, ERROR, null)
 	}
-	
+
 	def void addWarning(String message, EObject context) {
-		add(message, context, WARNING)
+		add(message, context, WARNING, null)
 	}
-	
-	def void add(String message, EObject context, Severity severity);
-	
+
+	def void add(String message, EObject context, Severity severity) {
+		add(message, context, severity, null);
+	}
+
+	def void add(String message, EObject context, Severity severity, /* nullable */ String issueCode, String... issueData);
+
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/processing/ValidationAcceptorImpl.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/processing/ValidationAcceptorImpl.xtend
@@ -51,16 +51,21 @@ class ValidationAcceptorImpl implements ValidationAcceptorExt {
 	}
 
 	def void addError(String message, EObject context, EStructuralFeature feature) {
-		add(message, context, ERROR, feature);
+		add(message, context, ERROR, feature, null);
 	}
 
 	def void addWarning(String message, EObject context, EStructuralFeature feature) {
-		add(message, context, WARNING, feature);
+		add(message, context, WARNING, feature, null);
 	}
 
 	def void addInfo(String message, EObject context, EStructuralFeature feature) {
-		add(message, context, INFO, feature);
+		add(message, context, INFO, feature, null);
 	}
+
+	override add(String message, EObject context, Severity severity, String issueCode, String... issueData) {
+		add(message, context, severity, null, issueCode, issueData);
+	}
+
 
 	override int getErrorCount() {
 		return ERROR.issueCount;
@@ -96,13 +101,15 @@ class ValidationAcceptorImpl implements ValidationAcceptorExt {
 		return #[errorCount, warningCount, infoCount]
 	}
 
-	private def newDiagnosti(String message, EObject context, Severity severity, EStructuralFeature feature) {
+	private def newDiagnosti(String message, EObject context, Severity severity, EStructuralFeature feature,
+		/* nullable */ String issueCode, String... issueData) {
+
 		return new FeatureBasedDiagnostic(DIAGNOSTIC_MAPPING.get(severity), message, context, feature,
-			INSIGNIFICANT_INDEX, NORMAL, ISSUE_CODE);
+			INSIGNIFICANT_INDEX, NORMAL, issueCode ?: ISSUE_CODE, issueData);
 	}
 
-	private def add(String message, EObject context, Severity severity, EStructuralFeature feature) {
-		val diagnostic = newDiagnosti(message, context, severity, feature);
+	private def add(String message, EObject context, Severity severity, EStructuralFeature feature, /* nullable */ String issueCode, String... issueData) {
+		val diagnostic = newDiagnosti(message, context, severity, feature, issueCode, issueData);
 		converter.convertValidatorDiagnostic(diagnostic, acceptor);
 		counter.increment(severity);
 	}


### PR DESCRIPTION
The validation for the incorrect name detection was already in place: https://github.com/crapo/sadlos2/commit/a29ecf0ce20529107893588ce8fd49c5630ec81e#diff-00be580bebaf34917cfb6ac809e73015R10096-R10131

I had to update the issue acceptor API a bit, I have exposed the `issueCode`. The `issueCode` is used to associate a `Diagnostic` with the corresponding quick-fix logic. I also exposed the `issueData` (`String[]`) so that we do not have to recalculate the local name when applying the quick fix.

Note:
 - The implementation of the quick-fix must have the following method signature.
```java
void feelFreeToPickAnyMethodName(Issue issue, IssueResolutionAcceptor acceptor)
```
 - The name of the method can be arbitrary.
 - The method must be annotated with `@Fix` and must contain the `issueCode` of the `Diagnostic`.
 - Also, on one of the screecasts, you can see `sfc` is proposed twice as quick-fix; it's becasue the `JenaBasedSadlModelProcessor#assignInstancePropertyValue` is invoked twice, hence we end up with two diagnostics. I did not invesitgate this oddity. Let me know if I should. Thank you!

In action:

![screencast 2020-01-21 11-31-15](https://user-images.githubusercontent.com/1405703/72797735-f3db5580-3c41-11ea-9e69-88964f98c6d9.gif)
![screencast 2020-01-21 11-32-19](https://user-images.githubusercontent.com/1405703/72797736-f473ec00-3c41-11ea-9c4e-545c16cd9a66.gif)


Signed-off-by: Akos Kitta <kittaakos@typefox.io>