### PR TITLE
Enabled caching in model the processor

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
@@ -44,6 +44,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -227,6 +228,7 @@ import com.ge.research.sadl.utils.ResourceManager;
 import com.ge.research.sadl.utils.SadlASTUtils;
 import com.ge.research.sadl.utils.SadlProjectHelper;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;
 import com.hp.hpl.jena.datatypes.TypeMapper;
 import com.hp.hpl.jena.datatypes.xsd.XSDDatatype;
@@ -380,6 +382,27 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 																		// translator output? default false
 
 	private DeclarationExtensions declarationExtensions;
+
+	private Map<String, List<ConceptName>> impliedPropoertiesCache = new HashMap<>();
+	private Map<String, Boolean> classIsSubclassOfCache = new HashMap<>();
+
+	protected boolean classIsSubclassOfCached(OntClass subcls, OntResource cls, boolean rootCall, List<OntResource> previousClasses) throws CircularDependencyException {
+		String key = new StringBuilder()
+				.append(subcls == null ? "null" : subcls.getURI())
+				.append("-")
+				.append(cls == null ? "null" : cls.getURI())
+				.append("-")
+				.append(rootCall)
+				.append("-")
+				.append(previousClasses == null ? "null" : String.join(",", previousClasses.stream().map(OntResource::getURI).collect(Collectors.toList())))
+				.toString();
+		Boolean result = classIsSubclassOfCache.get(key);
+		if (result == null) {
+			result = SadlUtils.classIsSubclassOf(subcls, cls, rootCall, previousClasses);
+			classIsSubclassOfCache.put(key, result);
+		}
+		return result;
+	}
 
 	public class DataDescriptor {
 		private Node name = null;
@@ -1018,6 +1041,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 	public void onValidate(Resource resource, ValidationAcceptor issueAcceptor, CheckMode mode,
 			ProcessorContext context) {
 
+		Stopwatch stopwatch = Stopwatch.createStarted();
 		logger.debug("onValidate called for Resource '" + resource.getURI() + "'");
 		if (mode.shouldCheck(CheckType.EXPENSIVE)) {
 			// do expensive validation, i.e. those that should only be done when 'validate'
@@ -1191,7 +1215,6 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 				processModelElement(element);
 			}
 		}
-		logger.debug("onValidate completed for Resource '" + resource.getURI() + "'");
 		if (getSadlCommands() != null && getSadlCommands().size() > 0) {
 			OntModelProvider.attach(model.eResource(), getTheJenaModel(), getModelName(), getModelAlias(),
 					getSadlCommands());
@@ -1228,6 +1251,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 				e.printStackTrace();
 			}
 		}
+		logger.debug("onValidate completed for resource '" + resource.getURI() + "' [took " + stopwatch + "]");
 	}
 
 	@Override
@@ -4816,7 +4840,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 		OntResource newCls = getTheJenaModel().getOntResource(((NamedNode) subcls).toFullyQualifiedString());
 		if (curCls != null && newCls != null && curCls.canAs(OntClass.class) && newCls.canAs(OntClass.class)) {
 			try {
-				if (SadlUtils.classIsSubclassOf(newCls.as(OntClass.class), curCls.as(OntClass.class), true, null)) {
+				if (classIsSubclassOfCached(newCls.as(OntClass.class), curCls.as(OntClass.class), true, null)) {
 					return true; // OK if subclass
 				}
 			} catch (CircularDependencyException e) {
@@ -5021,10 +5045,10 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 					OntResource suprclass = theJenaModel.getOntResource(SadlConstants.SADL_IMPLICIT_MODEL_EVENT_URI);
 					if(subclassl != null && subclassr != null) {
 						try {
-							if (SadlUtils.classIsSubclassOf(subclassl, suprclass, true, null) && SadlUtils.classIsSubclassOf(subclassr,suprclass,true,null)) {
+							if (classIsSubclassOfCached(subclassl, suprclass, true, null) && classIsSubclassOfCached(subclassr,suprclass,true,null)) {
 
 								try {
-									if (SadlUtils.classIsSubclassOf(subclassr,suprclass,true,null)){
+									if (classIsSubclassOfCached(subclassr,suprclass,true,null)){
 										if(isConjunction(op)){
 											
 											eventConj.add(tr);
@@ -5413,7 +5437,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 				if (!oldType.equals(restrictionType)) {
 					OntResource oldRsrc = getTheJenaModel().getOntResource(((NamedNode)oldType).getURI());
 					OntClass newRsrc = getTheJenaModel().getOntClass(restrictionType.getURI());
-					if (oldRsrc != null && newRsrc != null && !SadlUtils.classIsSubclassOf(newRsrc, oldRsrc, true, null)) {
+					if (oldRsrc != null && newRsrc != null && !classIsSubclassOfCached(newRsrc, oldRsrc, true, null)) {
 						if (!(getTarget() instanceof Rule) || !getRulePart().equals(RulePart.CONCLUSION)) {
 							// this is not consistent	this is OK to have in a rule conclusion--it is concluding, not conditioning
 							addTypeCheckingError("Restriction on variable type must be a subclass of type from definition.", expr);
@@ -9490,7 +9514,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 			throws JenaProcessorException {
 		// this is changing the range of a property defined in a different model
 		try {
-			if (SadlUtils.classIsSubclassOf((OntClass) rangeCls, existingRange, true, null)) {
+			if (classIsSubclassOfCached((OntClass) rangeCls, existingRange, true, null)) {
 				return true;
 			}
 		} catch (CircularDependencyException e) {
@@ -12324,12 +12348,12 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 					try {
 						if (or.isURIResource()) {
 							OntClass oc = m.getOntClass(or.getURI());
-							if (SadlUtils.classIsSubclassOf(oc, cls, true, null)) {
+							if (classIsSubclassOfCached(oc, cls, true, null)) {
 								eitr.close();
 								return true;
 							}
 						} else if (or.canAs(OntClass.class)) {
-							if (SadlUtils.classIsSubclassOf(or.as(OntClass.class), cls, true, null)) {
+							if (classIsSubclassOfCached(or.as(OntClass.class), cls, true, null)) {
 								eitr.close();
 								return true;
 							}
@@ -12991,11 +13015,15 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 			addError("Can't get implied properties of a non-class entity. Perhaps this can't be used before it is declared?", getDefaultEObject());
 			return null;
 		}
+		List<ConceptName> cached = impliedPropoertiesCache.get(cls.getURI());
+		if (cached != null) {
+			return cached;
+		}
 		List<OntResource> allImplPropClasses = getAllImpliedPropertyClasses();
 		if (allImplPropClasses != null) {
 			for (OntResource ipcls : allImplPropClasses) {
 				try {
-					if (SadlUtils.classIsSubclassOf(cls.as(OntClass.class), ipcls, true, null)) {
+					if (classIsSubclassOfCached(cls.as(OntClass.class), ipcls, true, null)) {
 						StmtIterator sitr = getTheJenaModel().listStatements(ipcls,
 								getTheJenaModel().getProperty(SadlConstants.SADL_IMPLICIT_MODEL_IMPLIED_PROPERTY_URI),
 								(RDFNode) null);
@@ -13020,6 +13048,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 				}
 			}
 		}
+		impliedPropoertiesCache.put(cls.getURI(), retlst);
 		return retlst;
 	}
 
@@ -13966,7 +13995,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
  						match = true;
  					} else {
  						try {
- 							if (typ.canAs(OntClass.class) && SadlUtils.classIsSubclassOf(typ.as(OntClass.class), type.as(OntClass.class), true, null)) {
+ 							if (typ.canAs(OntClass.class) && classIsSubclassOfCached(typ.as(OntClass.class), type.as(OntClass.class), true, null)) {
  								match = true;
  							}
  						} catch (CircularDependencyException e) {


### PR DESCRIPTION
This PR enables some caching in the SADL model processor. I've profiled the application and made it faster for larger models, such as `Turbo.sadl`.

Performance numbers without the change (from `MissingPatterns`):
```
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 7.892 s]
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 6.922 s]
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 6.877 s]
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 7.498 s]
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 6.834 s]
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 7.581 s]
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 7.847 s]
```

Performance numbers with my changes:
```
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 418.1 ms]
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 370.5 ms]
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 365.4 ms]
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 365.3 ms]
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 373.8 ms]
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 378.1 ms]
onValidate completed for resource 'platform:/resource/ASKE_P2/Turbo.sadl' [took 355.5 ms]
```
We are down from an avareage `7350 ms` to `322 ms`.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>