### PR TITLE
Java9+

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-api/pom.xml
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-api/pom.xml
@@ -53,6 +53,11 @@
       <version>4.8.1</version>
       <scope>test</scope>
     </dependency>
+	<dependency>
+		<groupId>javax.activation</groupId>
+		<artifactId>activation</artifactId>
+		<version>1.1</version>
+	</dependency>
   </dependencies>
   
 	<!-- Define where to deploy this project's artifacts -->


### PR DESCRIPTION
@crapo, with this change, we should be able to build the project on Java9+. Java 8 will be still supported, the compiler compliance level is still JDK 1.8. Same for Maven:
```xml
  <maven.compiler.source>1.8</maven.compiler.source>
  <maven.compiler.target>1.8</maven.compiler.target>
```

I thought this would be useful for users, and for us as well. Simplifies the development process:

From the [Installation Instructions for SADL IDE, Version 3.2](https://github.com/crapo/sadlos2/wiki/Installation-Instructions-for-SADL-IDE,-Version-3.2):
> If not already installed, install Java 1.8 from http://www.java.com (Java 1.8 required!). (See How to check Java Version.)