### PR TITLE
Fix eclipse orbit p2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       - export MAVEN_OPTS="-Dmaven.repo.local=$HOME/.m2/repository -Xms1024m -Xmx3072m -XX:PermSize=512m"
     script:
       - mvn -f ./sadl3/com.ge.research.sadl.parent/pom.xml clean
-      - mvn -f ./sadl3/com.ge.research.sadl.parent/pom.xml verify
+      - mvn -f ./sadl3/com.ge.research.sadl.parent/pom.xml verify -U
 
   - stage: "Theia build [yarn]"
     language: java
@@ -40,7 +40,7 @@ jobs:
       - nvm use 10.15.3
     script:
       - mvn -f ./sadl3/com.ge.research.sadl.parent/pom.xml clean
-      - mvn -f ./sadl3/com.ge.research.sadl.parent/pom.xml -Dmaven.test.skip=true verify
+      - mvn -f ./sadl3/com.ge.research.sadl.parent/pom.xml -Dmaven.test.skip=true verify -U
       - yarn --cwd ./sadl3/com.ge.research.sadl.parent/theia-sadl-extension
     before_deploy:
       - printf "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}\n" >> ~/.npmrc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ platform:
 
 build_script:
   - mvn -f ./sadl3/com.ge.research.sadl.parent/pom.xml clean
-  - mvn -f ./sadl3/com.ge.research.sadl.parent/pom.xml verify
+  - mvn -f ./sadl3/com.ge.research.sadl.parent/pom.xml verify -U
 
 cache:
  - C:\Users\appveyor\.m2

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.target/com.ge.research.sadl.target.target
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.target/com.ge.research.sadl.target.target
@@ -12,7 +12,7 @@
         <unit id="org.jsoup.source" version="1.7.2.v201411291515"/>
         <unit id="javax.activation" version="1.1.0.v201211130549"/>
         <unit id="javax.activation.source" version="1.1.0.v201211130549"/>
-        <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/I20200203200403/repository/"/>
+        <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
         <unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>


### PR DESCRIPTION
@crapo, I have fixed the build. It seems, from now on, we have force the snapshot updates for the maven builds with the `-U` flag.

`mvn verify` should be `mvn verify -U`, and `mvn install` should be `mvn install -U` to avoid such issues in the future.

I have updated the CIs to do the same.

Closes #424.