### PR TITLE
Fix Activation API problems

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.jena/pom.xml
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.jena/pom.xml
@@ -15,12 +15,6 @@
 	    <groupId>com.ge.research.sadl</groupId>
 	    <artifactId>reasoner-api</artifactId>
 	    <version>${project.version}</version>
-	    <exclusions>
-		<exclusion>
-		    <groupId>javax.activation</groupId>
-		    <artifactId>activation</artifactId>
-		</exclusion>
-	    </exclusions>
 	</dependency>
 	<dependency>
 	    <groupId>com.ge.research.sadl</groupId>

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  com.ge.research.jena,
  com.ge.research.sadl.jena,
  com.google.gson,
- com.ge.research.sadl.jena-wrapper-for-sadl
+ com.ge.research.sadl.jena-wrapper-for-sadl,
+ javax.activation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.ge.research.sadl.ide,
  com.ge.research.sadl.ide.contentassist.antlr,

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Vendor: GE Global Research
 Require-Bundle: com.ge.research.jena,
  com.ge.research.sadl,
  com.ge.research.sadl.jena,
+ javax.activation,
  org.eclipse.core.runtime,
  org.eclipse.osgi,
  org.apache.log4j,

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-api/pom.xml
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-api/pom.xml
@@ -12,10 +12,9 @@
 
     <dependencies>
 	<dependency>
-	    <groupId>javax.activation</groupId>
-	    <artifactId>activation</artifactId>
-	    <version>1.1</version>
-	    <scope>provided</scope>
+	    <groupId>com.sun.activation</groupId>
+	    <artifactId>jakarta.activation</artifactId>
+	    <version>1.2.2</version>
 	</dependency>
         <dependency>
             <groupId>net.sf.opencsv</groupId>

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.swi-prolog-plugin/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.swi-prolog-plugin/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Require-Bundle: org.eclipse.core.runtime,
  com.ge.research.sadl,
  org.apache.log4j,
  com.ge.research.jena,
+ javax.activation,
  org.junit;bundle-version="4.12.0";resolution:=optional
 Eclipse-RegisterBuddy: com.ge.research.sadl
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-SymbolicName: com.ge.research.sadl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: com.ge.research.sadl,
  com.ge.research.sadl.ide;visibility:=reexport,
+ javax.activation,
  org.eclipse.xtext.ui;bundle-version="[2.21.0,2.22.0)",
  org.eclipse.ui.console,
  org.eclipse.ui.editors,


### PR DESCRIPTION
Add javax.activation to the Require-Bundle header in the MANIFEST.MF
files of the following modules:

    com.ge.research.sadl.ide
    com.ge.research.sadl.jena-wrapper-for-sadl
    com.ge.research.sadl.swi-prolog-plugin
    com.ge.research.sadl.ui

Update/remove the Maven dependency/exclusion for javax.activation in
the pom.xml files of the following modules:

    com.ge.research.jena
    com.ge.research.sadl.reasoner-api

Now we should be able to compile and run SADL 3.4 without any
javax.activation problems in both Java 8 and Java 11.

Note we don't need to add jakarata.activation.jar to com.ge.research.jena's
build.properties or MANIFEST.MF because Eclipse already has an activation
bundle in its ORBIT repository.  The Require-Bundle changes above ensure
that Eclipse will add that activation bundle to our modules' classpaths.