### PR TITLE
Resolution to issue #559, no feedback on empty derivations

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/src/com/ge/research/sadl/ide/handlers/SadlRunInferenceHandler.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/src/com/ge/research/sadl/ide/handlers/SadlRunInferenceHandler.java
@@ -41,6 +41,7 @@ import org.eclipse.xtext.validation.Issue;
 import com.ge.research.sadl.builder.MessageManager.MessageType;
 import com.ge.research.sadl.builder.MessageManager.SadlMessage;
 import com.ge.research.sadl.jena.importer.CsvImporter;
+import com.ge.research.sadl.jena.reasoner.builtin.GetInstance;
 import com.ge.research.sadl.model.Explanation;
 import com.ge.research.sadl.model.SadlSerializationFormat;
 import com.ge.research.sadl.model.gp.EndWrite;
@@ -55,8 +56,10 @@ import com.ge.research.sadl.preferences.SadlPreferences;
 import com.ge.research.sadl.reasoner.ConfigurationException;
 import com.ge.research.sadl.reasoner.ConfigurationManagerFactory;
 import com.ge.research.sadl.reasoner.IConfigurationManager;
+import com.ge.research.sadl.reasoner.IReasoner;
 import com.ge.research.sadl.reasoner.ModelError;
 import com.ge.research.sadl.reasoner.ModelError.ErrorType;
+import com.ge.research.sadl.reasoner.ReasonerNotFoundException;
 import com.ge.research.sadl.reasoner.ReasonerTiming;
 import com.ge.research.sadl.reasoner.ResultSet;
 import com.ge.research.sadl.reasoner.SadlCommandResult;
@@ -327,6 +330,17 @@ public class SadlRunInferenceHandler extends SadlIdeActionHandler {
 		if (getLastDerivation() != null) {
 			DataSource ds = getLastDerivation();
 			console.info(writeDerivationsToFile(trgtFile, ds));
+		}
+		else if (inferenceProcessor != null) {
+			String dl;
+			try {
+				dl = inferenceProcessor.getReasonerConfigurationItem(IReasoner.DerivationsRequestedKey);
+				if (dl != null && dl.length() > 0) {
+					console.info("Derivation information requested but none available.");
+				}
+			} catch (Exception e) {
+				console.error("Error getting reasoner configuration for derivations: " + e.getMessage());
+			}
 		}
     	if (numTests > 0) {
     		String msg = "Test summary: ";

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/ge/research/sadl/jena/reasoner/JenaReasonerPlugin.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/ge/research/sadl/jena/reasoner/JenaReasonerPlugin.java
@@ -145,6 +145,7 @@ import com.ge.research.sadl.reasoner.ConfigurationItem.NameValuePair;
 import com.ge.research.sadl.reasoner.ConfigurationManagerFactory;
 import com.ge.research.sadl.reasoner.ConfigurationOption;
 import com.ge.research.sadl.reasoner.IConfigurationManager;
+import com.ge.research.sadl.reasoner.IReasoner;
 import com.ge.research.sadl.reasoner.ITranslator;
 import com.ge.research.sadl.reasoner.InferenceCanceledException;
 import com.ge.research.sadl.reasoner.InvalidDerivationException;
@@ -3658,6 +3659,22 @@ public class JenaReasonerPlugin extends Reasoner{
 			}
 		}
 		return false;
+	}
+
+	@Override
+	public String getReasonerConfigurationItem(String itemKey) {
+		if (configuration != null) {
+			if (itemKey.equals(IReasoner.DerivationsRequestedKey)) {
+				return configuration.get(pDerivationLogging).toString();
+			}
+			else if (itemKey.contentEquals(IReasoner.QueryTimeoutKey)) {
+				return configuration.get(pTimeOut).toString();
+			}
+			else {
+				return configuration.get(itemKey).toString();
+			}
+		}
+		return null;
 	}
 
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlInferenceProcessor.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlInferenceProcessor.java
@@ -1865,4 +1865,9 @@ public class JenaBasedSadlInferenceProcessor implements ISadlInferenceProcessor 
 		return null;
 	}
 
+	@Override
+	public String getReasonerConfigurationItem(String itemKey) throws ConfigurationException, ReasonerNotFoundException {
+		return getInitializedReasoner().getReasonerConfigurationItem(itemKey);
+	}
+
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-api/src/main/java/com/ge/research/sadl/reasoner/IReasoner.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-api/src/main/java/com/ge/research/sadl/reasoner/IReasoner.java
@@ -45,6 +45,11 @@ public interface IReasoner {
 
 	public final static String TotalReasoningTime = "TotalReasoningTime";
 	
+	// Reasoner-independent keys to configuration values
+	//	(getReasonerConfigurationItem should map from this key to the reasoner-specific key, if different)
+	public final static String DerivationsRequestedKey = "DerivationsRequested";
+	public final static String QueryTimeoutKey = "QueryTimeout";
+	
 	/**
 	 * Method to configure the reasoner properties
 	 * @param  preferences
@@ -415,5 +420,11 @@ public interface IReasoner {
 	 * @return
 	 */
 	public List<ModelError> getErrors();
+
+	/**
+	 * Method to obtain a reasoner configuration value
+	 * @param itemKey -- the key to the desired value
+	 */
+	public String getReasonerConfigurationItem(String itemKey);	
 
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.swi-prolog-plugin/src/main/java/com/ge/research/sadl/swi_prolog/reasoner/SWIPrologReasonerPlugin.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.swi-prolog-plugin/src/main/java/com/ge/research/sadl/swi_prolog/reasoner/SWIPrologReasonerPlugin.java
@@ -981,4 +981,10 @@ public class SWIPrologReasonerPlugin extends Reasoner {
 		return null;
 	}
 
+	@Override
+	public String getReasonerConfigurationItem(String itemKey) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/preferences/SadlPreferences.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/preferences/SadlPreferences.java
@@ -28,7 +28,7 @@ import com.ge.research.sadl.model.SadlSerializationFormat;
 public class SadlPreferences {
 	
 	public static final PreferenceKey SADL_BASE_URI= new PreferenceKey("baseUri", "http://sadl.org");
-	public static final PreferenceKey OWL_MODEL_FORMAT = new PreferenceKey("OWL_Format", "");
+	public static final PreferenceKey OWL_MODEL_FORMAT = new PreferenceKey("OWL_Format", SadlSerializationFormat.RDF_XML_ABBREV_FORMAT);
 	public static final PreferenceKey RDF_XML_FORMAT = new PreferenceKey(SadlSerializationFormat.RDF_XML_FORMAT, ""); // default
 	public static final PreferenceKey RDF_XML_ABBREV_FORMAT = new PreferenceKey(SadlSerializationFormat.RDF_XML_ABBREV_FORMAT, "");
 	public static final PreferenceKey N_TRIPLE_FORMAT = new PreferenceKey(SadlSerializationFormat.N_TRIPLE_FORMAT, "");

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/processing/ISadlInferenceProcessor.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/processing/ISadlInferenceProcessor.xtend
@@ -114,5 +114,10 @@ interface ISadlInferenceProcessor {
 	 * @param preferenceMap
 	 */
 	def void setPreferences(Map<String, String> preferenceMap)
-	
+
+	/**
+	 * Method to obtain a reasoner configuration value
+	 * @param itemKey -- the key to the desired value
+	 */
+	def String getReasonerConfigurationItem(String itemKey)	throws ConfigurationException, ReasonerNotFoundException
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/processing/SadlInferenceProcessorProvider.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/processing/SadlInferenceProcessorProvider.xtend
@@ -79,6 +79,10 @@ class SadlInferenceProcessorProvider extends AbstractSadlProcessorProvider<ISadl
 			throw new UnsupportedOperationException("TODO: auto-generated method stub")
 		}
 		
+		override getReasonerConfigurationItem(String itemKey) {
+			throw new UnsupportedOperationException("TODO: auto-generated method stub")
+		}
+		
 	}
 
 	@Inject


### PR DESCRIPTION
Resolving issue #559 involved getting configuration values from the active reasoner back into the UI. To do so in a reasoner-independent manner, public keys for common items (e.g., derivation request, query timeout) have been added to IReasoner and methods getReasonerConfigurationItem have been added to the JenaBasedSadlInferenceProcessor and JenaReasonerPlugin. The specific reasoner implementation of the method is responsible for mapping from the IReasoner key to the local key. All tests pass.