### PR TITLE
Configure mavan-javadoc-plugin in all poms

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/pom.xml
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/pom.xml
@@ -16,4 +16,18 @@
       <module>com.ge.research.sadl.reasoner-impl</module>
   </modules>
 
+  <build>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.2.0</version>
+              <configuration>
+                  <doclint>none</doclint>
+                  <quiet>true</quiet>
+              </configuration>
+          </plugin>
+      </plugins>
+  </build>
+
 </project>

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/com.ge.research.sadl.server.server-api/src/main/java/com/ge/research/sadl/server/ISadlServer.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/com.ge.research.sadl.server.server-api/src/main/java/com/ge/research/sadl/server/ISadlServer.java
@@ -89,7 +89,6 @@ public interface ISadlServer {
 	 * 
 	 * @return -- class name
 	 * @throws SessionNotFoundException 
-	 * @throws com.ge.research.sadl.sadlserver.SessionNotFoundException 
 	 */
 	abstract public String getClassName() throws SessionNotFoundException;
 	
@@ -262,7 +261,6 @@ public interface ISadlServer {
      * @throws ConfigurationException 
      * @throws ReasonerNotFoundException 
      * @throws NamedServiceNotFoundException 
-     * @throws SessionNotFoundException 
      */
     abstract String selectServiceModel(String serviceName, List<ConfigurationItem> preferences) throws ConfigurationException, ReasonerNotFoundException, NamedServiceNotFoundException;
 
@@ -407,7 +405,6 @@ public interface ISadlServer {
      * reset to reflect those removals.
      * 
      * @return true if successful else false
-     * @throws TripleNotFoundException
      * @throws ReasonerNotFoundException 
      * @throws SessionNotFoundException 
      */

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/com.ge.research.sadl.server.server-api/src/main/java/com/ge/research/sadl/server/ISadlServerMD.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/com.ge.research.sadl.server.server-api/src/main/java/com/ge/research/sadl/server/ISadlServerMD.java
@@ -44,8 +44,9 @@ import com.ge.research.sadl.reasoner.ReasonerNotFoundException;
  * the super classes SadlServer and SadlServerPE. These methods are 
  * primarily convenience functions to support model-driven application,
  * e.g., model-driven user-interface.
+ *
  * MD--model-driven
- * => SadlServerMD
+ * =&gt; SadlServerMD
  *  
  * @author Andy Crapo
  *
@@ -104,7 +105,7 @@ import com.ge.research.sadl.reasoner.ReasonerNotFoundException;
 	 * This method returns all of the ancestor classes given a starting class,
 	 *  "className", in a class hierarchy.
 	 * 
-	 * @param root, the starting class type name 
+	 * @param className the starting class type name 
 	 * @return class names of all of the ancestors, or null if none were found
 	 * @throws ConfigurationException 
 	 * @throws ReasonerNotFoundException 
@@ -123,7 +124,7 @@ import com.ge.research.sadl.reasoner.ReasonerNotFoundException;
 	 * This method returns all of the direct super classes (one level up) given
 	 * a starting class, "className", in a class hierarchy.
 	 * 
-	 * @param root, the starting class type name 
+	 * @param className the starting class type name 
 	 * @return class names of all of the direct ancestors, or null if none were found
 	 * @throws ConfigurationException 
 	 * @throws ReasonerNotFoundException 
@@ -339,7 +340,6 @@ import com.ge.research.sadl.reasoner.ReasonerNotFoundException;
 	 * @param cls -- the localname, prefix:localname, or complete URI of the class
 	 * @return - an Object array of the allowed values, which will be of type Integer, String, Float, etc.
 	 * @throws IOException
-	 * @throws NameNotFoundException
 	 * @throws ReasonerNotFoundException 
 	 * @throws QueryParseException 
 	 * @throws ConfigurationException 

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/com.ge.research.sadl.server.server-api/src/main/java/com/ge/research/sadl/server/ISadlServerPE.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/com.ge.research.sadl.server.server-api/src/main/java/com/ge/research/sadl/server/ISadlServerPE.java
@@ -65,7 +65,7 @@ import com.ge.research.sadl.server.SessionNotFoundException;
  * 
  * P--persistence
  * E--editing
- * => SadlServerPE
+ * =&gt; SadlServerPE
  *  
  * @author Andy Crapo
  *
@@ -79,8 +79,8 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param owlInstanceFileName File name containing instance in OWL format. For absolute paths use "file:///"
 	 * @param globalPrefix Global prefix (must be unique in the knowledge base)
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.ConfigurationException
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws ConfigurationException
+	 * @throws SessionNotFoundException
 	 * @throws IOException 
 	 */
 	abstract public boolean persistInstanceModel(String owlInstanceFileName, String globalPrefix) throws ConfigurationException, SessionNotFoundException, IOException;
@@ -94,8 +94,8 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param owlInstanceFileName File name containing instance in OWL format
 	 * @param globalPrefix Global prefix
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.ConfigurationException
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws ConfigurationException
+	 * @throws SessionNotFoundException
 	 * @throws IOException 
 	 */
 	abstract public boolean persistInstanceModel(String modelName, String owlInstanceFileName, String globalPrefix) throws ConfigurationException, SessionNotFoundException, IOException;
@@ -105,7 +105,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * service model or to any of the models that it imports.
 	 * 
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 */
 	abstract public boolean persistChangesToServiceModels()	throws SessionNotFoundException;
 	
@@ -114,7 +114,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * clears the errors--a second immediate call will return no errors.
 	 * 
 	 * @return List of errors since last call or null if none
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 */
 	abstract public List<ModelError> getErrors() throws SessionNotFoundException;
 
@@ -126,10 +126,10 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param predicate Predicate
 	 * @param value Object value
 	 * @return True if operation was successful, false otherwise
-	 * @throws com.ge.research.sadl.server.ConfigurationException
-	 * @throws com.ge.research.sadl.server.ReasonerNotFoundException 
-	 * @throws com.ge.research.sadl.server.TripleNotFoundException 
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws ConfigurationException
+	 * @throws ReasonerNotFoundException 
+	 * @throws TripleNotFoundException 
+	 * @throws SessionNotFoundException
 	 */
 	abstract public boolean addTriple(String modelName, String subject, String predicate, Object value) 
 			throws ConfigurationException, TripleNotFoundException, ReasonerNotFoundException, SessionNotFoundException;
@@ -157,10 +157,10 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param predicate Predicate
 	 * @param value Object value
 	 * @return True if operation was successful, false otherwise
-	 * @throws com.ge.research.sadl.server.ConfigurationException
-	 * @throws com.ge.research.sadl.server.ReasonerNotFoundException 
-	 * @throws com.ge.research.sadl.server.TripleNotFoundException 
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws ConfigurationException
+	 * @throws ReasonerNotFoundException 
+	 * @throws TripleNotFoundException 
+	 * @throws SessionNotFoundException
 	 */
 	abstract public boolean deleteTriple(String modelName, String subject, String predicate, Object value)
 			throws ConfigurationException, TripleNotFoundException, ReasonerNotFoundException, SessionNotFoundException;
@@ -171,7 +171,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param className Class name or null if none
 	 * @param superClassName Super class name or null if none
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addClass(String className, String superClassName) throws SessionNotFoundException, InvalidNameException;
@@ -183,7 +183,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param className Class name or null if none
 	 * @param superClassName Super class name or null if none
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addClass(String modelName, String className, String superClassName) throws SessionNotFoundException, InvalidNameException;
@@ -197,8 +197,8 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param namespace -- namespace of the new URI
 	 * @param baseLocalName -- local fragment base of the URI
 	 * @return -- a unique URI with the namespace and base fragment augmented to make it unique
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
-	 * @throws com.ge.research.sadl.server.InvalidNameException 
+	 * @throws SessionNotFoundException
+	 * @throws InvalidNameException 
 	 */
 	String getUniqueInstanceUri(String namespace, String baseLocalName) throws InvalidNameException, SessionNotFoundException;
 
@@ -212,8 +212,8 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param namespace -- namespace of the new URI
 	 * @param baseLocalName -- local fragment base of the URI
 	 * @return -- a unique URI with the namespace and base fragment augmented to make it unique
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
-	 * @throws com.ge.research.sadl.server.InvalidNameException 
+	 * @throws SessionNotFoundException
+	 * @throws InvalidNameException 
 	 */
 	String getUniqueInstanceUri(String modelName, String namespace, String baseLocalName) throws InvalidNameException, SessionNotFoundException;
 
@@ -225,8 +225,8 @@ public interface ISadlServerPE extends ISadlServer {
 	 * 
 	 * @param baseNamespace -- base namespace of the new URI
 	 * @return -- a unique namespace URI with base namespace augmented to make it unique
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
-	 * @throws com.ge.research.sadl.server.InvalidNameException 
+	 * @throws SessionNotFoundException
+	 * @throws InvalidNameException 
 	 * @throws ConfigurationException 
 	 * @throws MalformedURLException 
 	 */
@@ -239,7 +239,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param propertyName Property name
 	 * @param superPropertyName Super property name
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addOntProperty(String modelName, String propertyName,
@@ -253,7 +253,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param propertyName Property name
 	 * @param cardValue Cardinality value
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addMaxCardinalityRestriction(String modelName, String className,
@@ -267,7 +267,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param propertyName Property name
 	 * @param cardValue Cardinality value
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addMinCardinalityRestriction(String modelName, String className,
@@ -281,7 +281,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param propertyName Property name
 	 * @param cardValue Cardinality value
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addCardinalityRestriction(String modelName, String className,
@@ -296,7 +296,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param cardValue Cardinality value
 	 * @param restrictedToType class values are restricted to
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addMaxQualifiedCardinalityRestriction(String modelName, String className,
@@ -311,7 +311,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param cardValue Cardinality value
 	 * @param restrictedToType class values are restricted to
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addMinQualifiedCardinalityRestriction(String modelName, String className,
@@ -326,7 +326,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param cardValue Cardinality value
 	 * @param restrictedToType class values are restricted to
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addQualifiedCardinalityRestriction(String modelName, String className,
@@ -340,7 +340,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param propertyName Property name
 	 * @param valueInstanceName Value instance name
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addHasValueRestriction(String modelName, String className,
@@ -354,7 +354,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param propertyName Property name
 	 * @param restrictionName Restriction name
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addSomeValuesFromRestriction(String modelName, String className,
@@ -368,7 +368,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param propertyName Property name
 	 * @param restrictionName Restriction name
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	abstract boolean addAllValuesFromRestriction(String modelName, String className,
@@ -384,7 +384,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param owlFileName OWL file name
 	 * @param prefix global prefix name
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 */
 	boolean createServiceModel(String kbid, String serviceName, String modelName,
 			String owlFileName, String prefix) throws SessionNotFoundException;
@@ -426,7 +426,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param propertyName Property name
 	 * @param domainClassName Domain class name
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addOntPropertyDomainClass(String modelName, String propertyName,
@@ -439,7 +439,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param propertyName Property name
 	 * @param rangeClassName Range class name
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean addObjectPropertyRangeClass(String modelName, String propertyName,
@@ -452,7 +452,7 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param propertyName Property name
 	 * @param xsdRange XSD range fragment: string | boolean | decimal | int | long | float | double | duration | dateTime | time | date | gYearMonth | gYear | gMonthDay | gDay | gMonth | hexBinary | base64Binary | anyURI | data
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 * @throws InvalidNameException 
 	 */
 	boolean setDatatypePropertyRange(String modelName, String propertyName,
@@ -464,9 +464,9 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param modelName Model name
 	 * @param ruleAsString Rule
 	 * @return True if successful else false
-	 * @throws com.ge.research.sadl.server.ConfigurationException 
+	 * @throws ConfigurationException 
 	 * @throws IOException 
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws SessionNotFoundException
 	 */
 	boolean addRule(String modelName, String ruleAsString) throws ConfigurationException, IOException, SessionNotFoundException;
 
@@ -478,8 +478,8 @@ public interface ISadlServerPE extends ISadlServer {
 	 * @param modelName -- the public URI identifying the model to be deleted
 	 * @return
 	 * @throws IOException 
-	 * @throws com.ge.research.sadl.reasoner.ConfigurationException 
-	 * @throws com.ge.research.sadl.server.SessionNotFoundException
+	 * @throws ConfigurationException
+	 * @throws SessionNotFoundException
 	 */
 	boolean deleteModel(String modelName) throws ConfigurationException, IOException, SessionNotFoundException;
 	

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/com.ge.research.sadl.server.server-impl/src/main/java/com/ge/research/sadl/server/client/SadlServerMain.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/com.ge.research.sadl.server.server-impl/src/main/java/com/ge/research/sadl/server/client/SadlServerMain.java
@@ -115,8 +115,8 @@ public class SadlServerMain {
 	 *
 	 * @param args -- an array of values as described below
 	 * 
-	 * @throws NameNotFoundException 
-	 * @throws InvalidDerivation 
+	 * @throws IOException
+	 * @throws NameNotFoundException
 	 */
 	public static void main(String[] args) throws IOException, NameNotFoundException {
 		logger.info("SadlServerMain main, version $Revision: 1.4 $");
@@ -143,7 +143,6 @@ public class SadlServerMain {
 	 * This method has the same meaning of args as for the main method but is not a static invocation and returns the session key.
 	 * @param args -- see main method documentation
 	 * @return the session key of the session established by this processing call
-	 * @throws ApplicationLaunchException
 	 * @throws IOException
 	 * @throws NameNotFoundException
 	 * @throws QueryParseException 
@@ -152,7 +151,6 @@ public class SadlServerMain {
 	 * @throws InvalidNameException 
 	 * @throws SessionNotFoundException 
 	 * @throws NamedServiceNotFoundException 
-	 * @throws InvalidDerivation 
 	 */
 	public String process(String[] args) throws IOException, NameNotFoundException, QueryParseException, ReasonerNotFoundException, InvalidNameException, ConfigurationException, SessionNotFoundException, NamedServiceNotFoundException {
 		// arg[0]: ISadlServer implementing class fully qualified name
@@ -1005,7 +1003,6 @@ public class SadlServerMain {
 	 * @param cls -- the localname, prefix:localname, or complete URI of the class
 	 * @return - an Object array of the allowed values, which will be of type Integer, String, Float, etc.
 	 * @throws IOException
-	 * @throws NameNotFoundException
 	 * @throws ReasonerNotFoundException 
 	 * @throws QueryParseException 
 	 * @throws ConfigurationException 

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/com.ge.research.sadl.server.server-impl/src/main/java/com/ge/research/sadl/server/server/SadlServerMDImpl.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/com.ge.research.sadl.server.server-impl/src/main/java/com/ge/research/sadl/server/server/SadlServerMDImpl.java
@@ -168,7 +168,6 @@ public class SadlServerMDImpl extends SadlServerPEImpl implements ISadlServerMD 
 	 * @throws URISyntaxException 
 	 * @throws IOException 
 	 * @throws AmbiguousNameException 
-	 * @throws InvalidClassDomainException, InvalidConfigurationException
 	 */
 	public String[] getAncestorClassesOfTaxonomy(String className)
 			 throws InvalidNameException, ReasonerNotFoundException, ConfigurationException,
@@ -192,7 +191,6 @@ public class SadlServerMDImpl extends SadlServerPEImpl implements ISadlServerMD 
 	 * @throws URISyntaxException 
 	 * @throws IOException 
 	 * @throws AmbiguousNameException 
-	 * @throws InvalidClassDomainException, InvalidConfigurationException
 	 */
 	public String[] getDirectSuperclassesOfTaxonomy(String className)
 			 throws InvalidNameException, ReasonerNotFoundException, ConfigurationException,

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/pom.xml
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/pom.xml
@@ -13,4 +13,18 @@
       <module>com.ge.research.sadl.server.server-impl</module>
   </modules>
 
+  <build>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.2.0</version>
+              <configuration>
+                  <doclint>all,-missing</doclint>
+                  <quiet>true</quiet>
+              </configuration>
+          </plugin>
+      </plugins>
+  </build>
+
 </project>

--- a/sadl3/com.ge.research.sadl.parent/pom.xml
+++ b/sadl3/com.ge.research.sadl.parent/pom.xml
@@ -62,24 +62,34 @@
 		<finalName>${project.artifactId}-${sadlOsgiVersion}.${maven.build.timestamp}</finalName>
 		<plugins>
 			<plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-enforcer-plugin</artifactId>
-			<version>1.4.1</version>
-			<executions>
-				<execution>
-					<id>enforce-maven</id>
-					<goals>
-						<goal>enforce</goal>
-					</goals>
-					<configuration>
-						<rules>
-							<requireMavenVersion>
-								<version>[3.3.9,)</version>
-							</requireMavenVersion>
-						</rules>
-					</configuration>
-				</execution>
-			</executions>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.4.1</version>
+				<executions>
+					<execution>
+						<id>enforce-maven</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>[3.3.9,)</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.2.0</version>
+				<configuration>
+					<doclint>none</doclint>
+					<quiet>true</quiet>
+					<source>8</source>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
Configure mavan-javadoc-plugin as a build plugin in all parent poms of
module poms, but fix javadoc errors in only the
com.ge.research.sadl.server modules (didn't have time to fix all of
the javadoc errors everywhere).

To generate the com.ge.research.sadl.server javadocs, run the
following two commands,

    $ cd sadl/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server
    $ mvn package javadoc:javadoc javadoc:aggregate

and the javadocs will appear in the following directories:

    com.ge.research.sadl.server/target/site/apidocs (aggregating both below)
    com.ge.research.sadl.server/com.ge.research.sadl.server.server-api/target/site/apidocs
    com.ge.research.sadl.server/com.ge.research.sadl.server.server-impl/target/site/apidocs

If you want to generate the com.ge.research.sadl.reasoner javadocs,
you can cd into the com.ge.research.sadl.reasoner directory and run
the same Maven command there, but you should fix some errors in
reasoner's javadoc comments first.  Try configuring
maven-javadoc-plugin in the reasoner pom with
<doclint>all,-missing</doclint> instead of <doclint>none</doclint>
(doclint usually runs by default so you have to configure
maven-javadoc-plugin to turn off some or or all doclint checks).

If you try to generate javadocs in the com.ge.research.sadl.parent
directory, Maven will fail due to strange errors that I don't have
time to figure out.