### PR TITLE
Upload SADL zip file in workflows

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,21 +1,20 @@
-# Builds SADL and WebSADL on every pull request/push to main branch:
-#  - Builds SADL source
-#  - Builds WebSADL extension
-#  - Publishes WebSADL npm package (main branch only)
-#  - Pushes WebSADL image to Docker Hub (main branch only)
+# Runs after every pull request or push (except tag-only pushes)
 
-name: SADL continuous build
-
+name: SADL Continuous Integration Workflow
 on:
   pull_request:
     branches: [ development ]
   push:
     branches: [ development ]
-    # Ignore tag-only pushes
     tags-ignore: [ '*' ]
   workflow_dispatch:
 
 jobs:
+
+# Test job:
+#  - Builds SADL source
+#  - Runs unit tests
+
   test:
     strategy:
       matrix:
@@ -44,7 +43,16 @@ jobs:
       with:
         run: mvn -B package --file sadl3/com.ge.research.sadl.parent/pom.xml
 
-  web:
+# Build job:
+#  - Builds SADL source
+#  - Runs unit tests
+#  - Uploads SADL update repository
+#  - Builds WebSADL extension
+#  - Publishes WebSADL npm package
+#  - Builds WebSADL Docker image
+#  - Pushes Docker image to Docker Hub
+
+  build:
     strategy:
       matrix:
         java-version: [ 11 ]
@@ -71,6 +79,17 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
         run: mvn -B package --file sadl3/com.ge.research.sadl.parent/pom.xml
+
+    - name: Get SADL zip filename
+      run: |
+        cd sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.update/target
+        echo "sadlzip=$(echo com.ge.research.sadl.update*.zip | sed 's/.zip//')" >> $GITHUB_ENV
+
+    - name: Upload SADL update repository
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ env.sadlzip }}
+        path: sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.update/target/repository
 
     - name: Set up Node.js 10.x
       uses: actions/setup-node@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+# Runs after a release is created
+
+name: SADL Release Workflow
+on:
+  release:
+    types: [ created ]
+
+jobs:
+
+# Build job:
+#  - Builds SADL source
+#  - Runs unit tests
+#  - Uploads SADL zip file to GitHub release page
+
+  build:
+    strategy:
+      matrix:
+        java-version: [ 11 ]
+        os: [ ubuntu-latest ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Check out SADL source
+      uses: actions/checkout@v2
+
+    - name: Set up Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java-version }}
+
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ matrix.os }}-m2-${{ hashFiles('**/pom.xml') }}
+
+    - name: Build SADL source
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        run: mvn -B package --file sadl3/com.ge.research.sadl.parent/pom.xml
+
+    - name: Get SADL zip filename
+      run: |
+        cd sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.update/target
+        echo "sadlzip=$(echo com.ge.research.sadl.update*.zip)" >> $GITHUB_ENV
+
+    - name: Upload SADL zip file to GitHub release page
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.update/target/${{ env.sadlzip }}
+        asset_name: ${{ env.sadlzip }}
+        asset_content_type: application/zip


### PR DESCRIPTION
Rename build.yml to continous.yml and make it upload SADL update
repository as a build artifact (note uploading zip file creates a
double-zipped zip file).

Add release workflow and make it upload SADL zip file to GitHub
release page (uploading zip file works fine there).