### PR TITLE
fix to Issue #557

### DIFF
--- a/sadl3/Examples/TestSadl3Ide/Sandbox/GH594.sadl
+++ b/sadl3/Examples/TestSadl3Ide/Sandbox/GH594.sadl
@@ -6,3 +6,6 @@
  prop2 is a property with values of type boolean.
  subprop2 is a type of prop2.
  
+ C1 is a class, described by subprop1.
+ C2 is a class, described by prop1.
+ 

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/model/DeclarationExtensionsTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/model/DeclarationExtensionsTest.xtend
@@ -329,6 +329,27 @@ class DeclarationExtensionsTest {
 		assertEquals(OntConceptType.RDF_PROPERTY, name2resource.get('subprop1').ontConceptType)
 	}
 	
+	@Test
+	def void testGH557() {
+		val model = '''
+			 uri "http://sadl.org/test.sadl" alias test.
+			 
+			 Foo is a class described by bar with values of type Whim.
+			 Whim is a class described by wham with values of type string.
+			 MyFoo is a Foo with bar (a Whim MyWhim with wham "too bad").
+			 Ask: select x where MyFoo is an x.
+			 Ask: select c where MyFoo bar b and b is a c.
+ 		'''.parse
+		
+		val name2resource = model.eAllContents.filter(SadlResource).toMap[concreteName]
+		assertTrue(name2resource.containsKey('x'))
+		assertEquals(OntConceptType.VARIABLE, name2resource.get('x').ontConceptType)
+		assertTrue(name2resource.containsKey('b'))
+		assertEquals(OntConceptType.VARIABLE, name2resource.get('b').ontConceptType)
+		assertTrue(name2resource.containsKey('c'))
+		assertEquals(OntConceptType.VARIABLE, name2resource.get('c').ontConceptType)
+	}
+	
 	protected def void assertIs(SadlResource it, OntConceptType type) {
 		assertNotNull(it)
 		val typ = try {

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/scoping/SadlLinkingTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/scoping/SadlLinkingTest.xtend
@@ -1227,6 +1227,22 @@ class SadlLinkingTest extends AbstractLinkingTest {
 		'''.assertLinking[sadl]
 	}
 	
+	@Test 
+	def void testQueryVariable_3() {
+		// this illustrates an inconvenient result of the way the grammar is defined. In a construct of the form
+		//	x is a y, y can never be the declaration of y because it is a reference in the grammar. This is the crux
+		//	of Issue 557. 
+		'''
+			 uri "http://sadl.org/test.sadl" alias test.
+			 
+			 Foo is a class described by bar with values of type Whim.
+			 Whim is a class described by wham with values of type string.
+			 MyFoo is a Foo with bar (a Whim MyWhim with wham "too bad").
+			 Ask: select [x] where MyFoo is an <x>.
+			 Ask: select [c] where MyFoo bar [b] and <b> is a <c>.
+		'''.assertLinking[sadl]
+	}
+
 	@Test
 	def void testRuleVariable_1() {
 		'''

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/test/inference/GH_275_CheckTranslatorAndInferencerPluginTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/test/inference/GH_275_CheckTranslatorAndInferencerPluginTest.xtend
@@ -25,6 +25,8 @@ import java.util.List
 import com.ge.research.sadl.reasoner.ConfigurationItem
 import org.eclipse.xtext.preferences.PreferenceKey
 import com.ge.research.sadl.preferences.SadlPreferences
+import com.ge.research.sadl.reasoner.SadlCommandResult
+import com.ge.research.sadl.model.gp.TestResult
 
 /**
  * Test that demonstrate how to make assertions on the generated translator outputs, plus runs the inferencer too.
@@ -277,18 +279,23 @@ class GH_275_CheckTranslatorAndInferencerPluginTest extends AbstractSadlPlatform
 			 Print: "This test will pass only if OWL entailments are enabled in the reasoner.".
 			 Test: George is a Genius.
 			''')
-//		assertNoErrorsInWorkspace;
-		var List<ConfigurationItem> configItems = newArrayList
-		val String[] catHier = newArrayOfSize(1)
-		catHier.set(0, "Jena")
-		val ci = new ConfigurationItem(catHier)
-		ci.addNameValuePair("pModelSpec", "OWL_MEM_MINI_RULE")
-		configItems.add(ci)
-		assertInferencer('UseArticles.sadl', null, configItems) [
-			// TODO do something with the SADL commands after running the inferencer.
+			assertNoErrorsInWorkspace;
+			var List<ConfigurationItem> configItems = newArrayList
+			val String[] catHier = newArrayOfSize(1)
+			catHier.set(0, "Jena")
+			val ci = new ConfigurationItem(catHier)
+			ci.addNameValuePair("pModelSpec", "OWL_MEM_MINI_RULE")
+			configItems.add(ci)
+			assertInferencer('UseArticles.sadl', null, configItems) [
 			for (scr:it) {
 				println(scr.toString)
 			}
+			val scr = it.get(1)
+			assertTrue(scr instanceof SadlCommandResult)
+			val tr = (scr as SadlCommandResult).results
+			assertTrue(tr instanceof TestResult)
+			assertTrue((tr as TestResult).passed)
+			
 		];
 
 	}


### PR DESCRIPTION
This fixes issue #557 . This was a tricky one in that the grammar defies the desired solution, which is that the variable x in a query like "select x where MyInstance is an x." is defined in the where. This is because the reference to x in "is an x" is just that--a reference to a SadlResource, not an actual SadlResource. Therefore the declaration must be in the select but the type of x must be determined in the where. This is true in other cases besides queries, namely rules and tests. However, the implemented solution seems robust.