### PR TITLE
fix to Issue 407; flag now keeps track of type checking errors regard…

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/src/com/ge/research/sadl/ide/editor/contentassist/ProposalProviderFilterProvider.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/src/com/ge/research/sadl/ide/editor/contentassist/ProposalProviderFilterProvider.xtend
@@ -41,6 +41,7 @@ import static com.ge.research.sadl.processing.ISadlOntologyHelper.GrammarContext
 import static com.ge.research.sadl.sADL.SADLPackage.Literals.*
 
 import static extension org.eclipse.xtext.EcoreUtil2.*
+import com.ge.research.sadl.jena.JenaBasedSadlModelProcessor
 
 /**
  * Provides filter for removing items from the content proposal.
@@ -85,6 +86,11 @@ class ProposalProviderFilterProvider {
 			return [
 				if (SADL_RESOURCE == EClass) {
 					ontologyHelper.validate(ontologyContext, EObjectOrProxy as SadlResource);
+					if (processor instanceof JenaBasedSadlModelProcessor &&
+						(processor as JenaBasedSadlModelProcessor).isTypeCheckingErrorDetected) {
+							((processor as JenaBasedSadlModelProcessor).clearTypeCheckingErrorDetected());
+							return false;
+					}
 					return acceptor.apply(it);
 				}
 				return false;

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
@@ -365,6 +365,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 
 	private boolean lookingForFirstProperty = false; // in rules and other constructs, the first property may be
 														// significant (the binding, for example)
+	private boolean typeCheckingErrorDetected = false;
 
 	protected List<String> importsInOrderOfAppearance = null; // an ordered set of import URIs, ordered by appearance in
 																// file.
@@ -3979,6 +3980,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 		} else {
 			issueAcceptor.addError(message, expr);
 		}
+		this.setTypeCheckingErrorDetected(true);
 	}
 
 	/**
@@ -15425,5 +15427,17 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 
 	private void setEnableMetricsCollection(boolean enableMetricsCollection) {
 		this.enableMetricsCollection = enableMetricsCollection;
+	}
+
+	public void clearTypeCheckingErrorDetected() {
+		setTypeCheckingErrorDetected(false);
+	}
+
+	public boolean isTypeCheckingErrorDetected() {
+		return typeCheckingErrorDetected;
+	}
+
+	protected void setTypeCheckingErrorDetected(boolean typeCheckingErrorDetected) {
+		this.typeCheckingErrorDetected = typeCheckingErrorDetected;
 	}
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/tests/contentassist/SadlContentAssistTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/tests/contentassist/SadlContentAssistTest.xtend
@@ -334,4 +334,21 @@ class SadlContentAssistTest extends AbstractSadlContentAssistTest {
 		builder.assertProposalIsNot('Shape');
 	}
 
+	@Test
+	def void checkCA_PofS() {
+		// https://github.com/crapo/sadlos2/issues/407
+		val key = new PreferenceKey(SadlPreferences.TYPE_CHECKING_WARNING_ONLY.id, Boolean.TRUE.toString);
+		updatePreference(key);
+		
+		val builder = newBuilder('''
+			uri "http://sadl.org/x.sadl".
+			Shape is a class described by area with values of type float.
+			Rectangle is a type of Shape, described by height with values of type float, described by width with values of type float.
+			Circle is a type of Shape described by radius with values of type float.
+			Test: width of 
+		''');
+		builder.assertProposal('Rectangle');
+		builder.assertProposalIsNot('Circle');
+	}
+
 }


### PR DESCRIPTION
This modification fixes the issue in #407, which has to do with the preference setting to show type checking errors as warnings interfering with the filtering of content assist proposals. A test is provided. All tests pass.