### PR TITLE
PR for issue Gh 630: implementation of list built-ins for Jena reasoner

### DIFF
--- a/sadl3/Examples/TestSadl3Ide/Expressions/Precedence.sadl
+++ b/sadl3/Examples/TestSadl3Ide/Expressions/Precedence.sadl
@@ -18,9 +18,3 @@
  Expr: -PI+3*-e.
  Expr: -(PI)+3*(-e).
  Expr: e % PI.
- 
- Expr: element before v1 in v2.
- 
- 
- 
-  

--- a/sadl3/Examples/TestSadl3Ide/UsingListExpression.sadl
+++ b/sadl3/Examples/TestSadl3Ide/UsingListExpression.sadl
@@ -40,6 +40,10 @@
 
  Rule ListIndex:
  	if l1 is a YooHooList and index of yh2 in l1 is idx then print("Index of yh2: ", idx). 
+ 	
+ Rule ListLength:
+ 	if l1 is a YooHooList and len is length of l1 then print("Length of l1: ", len). 
+ 	
 
 // Rule ListFirst2:
 //   if lst is a YooHooList and 

--- a/sadl3/Examples/TestSadl3Ide/UsingListExpression.sadl
+++ b/sadl3/Examples/TestSadl3Ide/UsingListExpression.sadl
@@ -3,8 +3,47 @@
  Person is a class.
  PersonList is a type of Person List.
  
- External elementAt(PersonList lst, int idx) returns Person : "".
- Equation firstElement(PersonList people) returns Person: elementAt(people,0). 
- Equation lastElement(PersonList people) returns Person: elementAt(people,(length of people) - 1). 
+// External elementAt(PersonList lst, int idx) returns Person : "".
+// Equation firstElement(PersonList people) returns Person: elementAt(people,0). 
+// Equation lastElement(PersonList people) returns Person: elementAt(people,(length of people) - 1). 
  
+ YooHoo is a class.
+ YooHooList is a type of YooHoo List, described by selectedElement with values of type YooHoo.
+ l1 is the YooHooList [yh1, yh2, yh3, yh4].
+// yh1 is a YooHoo.
  
+// Expr: element before yh1 in l1.
+// Expr: element after yh1 in l1.
+// 
+// 
+// Expr: last element of l1.
+// Expr: first element of l1.
+ Expr: element 2 of l1.
+// Expr: index of yh1 in l1.
+// Expr: length of l1.
+ 
+ Rule ListFirst:
+   if l1 is a YooHooList and 
+   		first element of l1 is le1 then l1 has selectedElement le1 and print("ListFirst: ", le1).
+   		
+ Rule ListLast:
+ 	if l1 is a YooHooList and last element of l1 is lel then print("Last element of l1: ", lel).   	
+ 	
+ Rule ListAfter:
+ 	if l1 is a YooHooList and element after yh2 in l1 is lea then print("Element after yh2: ", lea). 
+   
+ Rule ListBefore:
+ 	if l1 is a YooHooList and element before yh3 in l1 is leb then print("Element before yh3: ", leb). 
+
+ Rule ListElementAt:
+ 	if l1 is a YooHooList and element 3 of l1 is le3 then print("Element 3: ", le3). 
+
+ Rule ListIndex:
+ 	if l1 is a YooHooList and index of yh2 in l1 is idx then print("Index of yh2: ", idx). 
+
+// Rule ListFirst2:
+//   if lst is a YooHooList and 
+//   		first element of lst is le1 then lst has selectedElement le1 and print("ListFirst2: ", le1).
+
+ Ask: select x, y where x is a YooHooList and x has selectedElement y. 
+  

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/META-INF/services/org.apache.jena.reasoner.rulesys.Builtin
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/META-INF/services/org.apache.jena.reasoner.rulesys.Builtin
@@ -37,3 +37,10 @@ com.ge.research.sadl.jena.reasoner.builtin.Sum
 com.ge.research.sadl.jena.reasoner.builtin.Tan
 com.ge.research.sadl.jena.reasoner.builtin.ThereExists
 com.ge.research.sadl.jena.reasoner.builtin.Unique
+com.naturalsemantics.sadl.jena.reasoner.builtin.ElementAfter
+com.naturalsemantics.sadl.jena.reasoner.builtin.ElementBefore
+com.naturalsemantics.sadl.jena.reasoner.builtin.ElementInList
+com.naturalsemantics.sadl.jena.reasoner.builtin.FirstElement
+com.naturalsemantics.sadl.jena.reasoner.builtin.Index
+com.naturalsemantics.sadl.jena.reasoner.builtin.LastElement
+com.naturalsemantics.sadl.jena.reasoner.builtin.Length

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/ElementAfter.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/ElementAfter.java
@@ -1,0 +1,100 @@
+/************************************************************************
+ * Copyright © 2021 - Natural Semantics, LLC. All Rights Reserved.
+ *
+ * Project: SADL
+ *
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ *
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ ***********************************************************************/
+package com.naturalsemantics.sadl.jena.reasoner.builtin;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.reasoner.rulesys.RuleContext;
+import org.apache.jena.util.iterator.ClosableIterator;
+import org.apache.jena.util.iterator.ExtendedIterator;
+
+import com.ge.research.sadl.jena.reasoner.builtin.TypedBaseBuiltin;
+
+/**
+ * This class implements a Jena Built-in function in the bodyCall method that takes a SADL typed 
+ * list and an element of that list as arguments and binds the next list element after the 
+ * specified element, if such exists, to the 3rd argument. If successful, the method returns true
+ * else it returns false.
+ * @author andy@naturalsemantics.com
+ */
+public class ElementAfter extends TypedBaseBuiltin {
+
+	private int argLength = 3;
+	
+	@Override
+	public String getName() {
+		return "elementAfter";
+	}
+
+    /**
+     * Return the expected number of arguments for this functor or 0 if the number is flexible.
+     */
+    public int getArgLength() {
+        return argLength;
+    }
+
+    /**
+     * This method is invoked when the builtin is called in a rule body.
+     * @param args the array of argument values for the builtin, this is an array 
+     * of Nodes, some of which may be Node_RuleVariables.
+     * @param length the length of the argument list, may be less than the length of the args array
+     * for some rule engines
+     * @param context an execution context giving access to other relevant data
+     * @return return true if the buildin predicate is deemed to have succeeded in
+     * the current environment
+     */
+    public boolean bodyCall(Node[] args, int length, RuleContext context) {
+        Node typedList = getArg(0, args, context);
+        Node slmfirst = NodeFactory.createURI("http://sadl.org/sadllistmodel#first");
+        ClosableIterator<Triple> itr = context.find(typedList, slmfirst, null);
+        if (itr.hasNext()) {
+        	Node firstElement = itr.next().getObject();
+        	if (firstElement != null) {
+        		return context.getEnv().bind(args[length - 1], firstElement);	     
+        	}
+        }
+        else {
+            ClosableIterator<Triple> itr2 = context.find(typedList, null, null);
+            if (itr2.hasNext()) {
+	            while (itr2.hasNext()) {
+	            	System.out.println(itr2.next().toString());
+	            }
+            }
+            else {
+            	ExtendedIterator<Triple> itr3 = context.getGraph().find();
+            	if (itr3.hasNext()) {
+	            	while (itr3.hasNext()) {
+	            		System.out.println(itr3.next().toString());
+	            	}
+            	}
+            	else {
+            		System.out.println(context.getGraph().toString());
+            	}
+            }
+        }
+        return false;
+    }
+
+	@Override
+	public String getFunctionSignatureString() {
+		return "elementAfter(string, string)string";
+	}
+
+
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/ElementBefore.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/ElementBefore.java
@@ -1,0 +1,100 @@
+/************************************************************************
+ * Copyright © 2021 - Natural Semantics, LLC. All Rights Reserved.
+ *
+ * Project: SADL
+ *
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ *
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ ***********************************************************************/
+package com.naturalsemantics.sadl.jena.reasoner.builtin;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.reasoner.rulesys.RuleContext;
+import org.apache.jena.util.iterator.ClosableIterator;
+import org.apache.jena.util.iterator.ExtendedIterator;
+
+import com.ge.research.sadl.jena.reasoner.builtin.TypedBaseBuiltin;
+
+/**
+ * This class implements a Jena Built-in function in the bodyCall method that takes a SADL typed 
+ * list and an element of that list as arguments and binds the list element before the 
+ * specified element, if such exists, to the 3rd argument. If successful, the method returns true
+ * else it returns false.
+ * @author andy@naturalsemantics.com
+ */
+public class ElementBefore extends TypedBaseBuiltin {
+
+	private int argLength = 3;
+	
+	@Override
+	public String getName() {
+		return "elementBefore";
+	}
+
+    /**
+     * Return the expected number of arguments for this functor or 0 if the number is flexible.
+     */
+    public int getArgLength() {
+        return argLength;
+    }
+
+    /**
+     * This method is invoked when the builtin is called in a rule body.
+     * @param args the array of argument values for the builtin, this is an array 
+     * of Nodes, some of which may be Node_RuleVariables.
+     * @param length the length of the argument list, may be less than the length of the args array
+     * for some rule engines
+     * @param context an execution context giving access to other relevant data
+     * @return return true if the buildin predicate is deemed to have succeeded in
+     * the current environment
+     */
+    public boolean bodyCall(Node[] args, int length, RuleContext context) {
+        Node typedList = getArg(0, args, context);
+        Node slmfirst = NodeFactory.createURI("http://sadl.org/sadllistmodel#first");
+        ClosableIterator<Triple> itr = context.find(typedList, slmfirst, null);
+        if (itr.hasNext()) {
+        	Node firstElement = itr.next().getObject();
+        	if (firstElement != null) {
+        		return context.getEnv().bind(args[length - 1], firstElement);	     
+        	}
+        }
+        else {
+            ClosableIterator<Triple> itr2 = context.find(typedList, null, null);
+            if (itr2.hasNext()) {
+	            while (itr2.hasNext()) {
+	            	System.out.println(itr2.next().toString());
+	            }
+            }
+            else {
+            	ExtendedIterator<Triple> itr3 = context.getGraph().find();
+            	if (itr3.hasNext()) {
+	            	while (itr3.hasNext()) {
+	            		System.out.println(itr3.next().toString());
+	            	}
+            	}
+            	else {
+            		System.out.println(context.getGraph().toString());
+            	}
+            }
+        }
+        return false;
+    }
+
+	@Override
+	public String getFunctionSignatureString() {
+		return "elementBefore(string, string)string";
+	}
+
+
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/ElementInList.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/ElementInList.java
@@ -1,0 +1,99 @@
+/************************************************************************
+ * Copyright © 2021 - Natural Semantics, LLC. All Rights Reserved.
+ *
+ * Project: SADL
+ *
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ *
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ ***********************************************************************/
+package com.naturalsemantics.sadl.jena.reasoner.builtin;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.reasoner.rulesys.RuleContext;
+import org.apache.jena.util.iterator.ClosableIterator;
+import org.apache.jena.util.iterator.ExtendedIterator;
+
+import com.ge.research.sadl.jena.reasoner.builtin.TypedBaseBuiltin;
+
+/**
+ * This class implements a Jena Built-in function in the bodyCall method that takes a SADL typed 
+ * list and an int index as arguments and binds the list element having that index, if such exists, 
+ * to the 3rd argument. If successful, the method returns true else it returns false.
+ * @author andy@naturalsemantics.com
+ */
+public class ElementInList extends TypedBaseBuiltin {
+
+	private int argLength = 3;
+	
+	@Override
+	public String getName() {
+		return "elementInList";
+	}
+
+    /**
+     * Return the expected number of arguments for this functor or 0 if the number is flexible.
+     */
+    public int getArgLength() {
+        return argLength;
+    }
+
+    /**
+     * This method is invoked when the builtin is called in a rule body.
+     * @param args the array of argument values for the builtin, this is an array 
+     * of Nodes, some of which may be Node_RuleVariables.
+     * @param length the length of the argument list, may be less than the length of the args array
+     * for some rule engines
+     * @param context an execution context giving access to other relevant data
+     * @return return true if the buildin predicate is deemed to have succeeded in
+     * the current environment
+     */
+    public boolean bodyCall(Node[] args, int length, RuleContext context) {
+        Node typedList = getArg(0, args, context);
+        Node slmfirst = NodeFactory.createURI("http://sadl.org/sadllistmodel#first");
+        ClosableIterator<Triple> itr = context.find(typedList, slmfirst, null);
+        if (itr.hasNext()) {
+        	Node firstElement = itr.next().getObject();
+        	if (firstElement != null) {
+        		return context.getEnv().bind(args[length - 1], firstElement);	     
+        	}
+        }
+        else {
+            ClosableIterator<Triple> itr2 = context.find(typedList, null, null);
+            if (itr2.hasNext()) {
+	            while (itr2.hasNext()) {
+	            	System.out.println(itr2.next().toString());
+	            }
+            }
+            else {
+            	ExtendedIterator<Triple> itr3 = context.getGraph().find();
+            	if (itr3.hasNext()) {
+	            	while (itr3.hasNext()) {
+	            		System.out.println(itr3.next().toString());
+	            	}
+            	}
+            	else {
+            		System.out.println(context.getGraph().toString());
+            	}
+            }
+        }
+        return false;
+    }
+
+	@Override
+	public String getFunctionSignatureString() {
+		return "elementInList(string, int)string";
+	}
+
+
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/FirstElement.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/FirstElement.java
@@ -68,7 +68,8 @@ public class FirstElement extends TypedBaseBuiltin {
         		return context.getEnv().bind(args[length - 1], firstElement);	     
         	}
         }
-        else {
+        boolean debug = true;;
+		if (debug ) {
             ClosableIterator<Triple> itr2 = context.find(typedList, null, null);
             if (itr2.hasNext()) {
 	            while (itr2.hasNext()) {

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/FirstElement.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/FirstElement.java
@@ -1,0 +1,98 @@
+/************************************************************************
+ * Copyright © 2021 - Natural Semantics, LLC. All Rights Reserved.
+ *
+ * Project: SADL
+ *
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ *
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ ***********************************************************************/
+package com.naturalsemantics.sadl.jena.reasoner.builtin;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.reasoner.rulesys.RuleContext;
+import org.apache.jena.util.iterator.ClosableIterator;
+import org.apache.jena.util.iterator.ExtendedIterator;
+
+import com.ge.research.sadl.jena.reasoner.builtin.TypedBaseBuiltin;
+
+/**
+ * This class implements a Jena Built-in function in the bodyCall method that takes a SADL typed 
+ * list as input argument and binds the first list element, if such exists, to the 2nd argument. 
+ * If successful, the method returns true else it returns false.
+ * @author andy@naturalsemantics.com
+ */
+public class FirstElement extends TypedBaseBuiltin {
+
+	private int argLength = 2;
+	
+	@Override
+	public String getName() {
+		return "firstElement";
+	}
+
+    /**
+     * Return the expected number of arguments for this functor or 0 if the number is flexible.
+     */
+    public int getArgLength() {
+        return argLength;
+    }
+
+    /**
+     * This method is invoked when the builtin is called in a rule body.
+     * @param args the array of argument values for the builtin, this is an array 
+     * of Nodes, some of which may be Node_RuleVariables.
+     * @param length the length of the argument list, may be less than the length of the args array
+     * for some rule engines
+     * @param context an execution context giving access to other relevant data
+     * @return return true if the buildin predicate is deemed to have succeeded in
+     * the current environment
+     */
+    public boolean bodyCall(Node[] args, int length, RuleContext context) {
+        Node typedList = getArg(0, args, context);
+        Node slmfirst = NodeFactory.createURI("http://sadl.org/sadllistmodel#first");
+        ClosableIterator<Triple> itr = context.find(typedList, slmfirst, null);
+        if (itr.hasNext()) {
+        	Node firstElement = itr.next().getObject();
+        	if (firstElement != null) {
+        		return context.getEnv().bind(args[length - 1], firstElement);	     
+        	}
+        }
+        else {
+            ClosableIterator<Triple> itr2 = context.find(typedList, null, null);
+            if (itr2.hasNext()) {
+	            while (itr2.hasNext()) {
+	            	System.out.println(itr2.next().toString());
+	            }
+            }
+            else {
+            	ExtendedIterator<Triple> itr3 = context.getGraph().find();
+            	if (itr3.hasNext()) {
+	            	while (itr3.hasNext()) {
+	            		System.out.println(itr3.next().toString());
+	            	}
+            	}
+            	else {
+            		System.out.println(context.getGraph().toString());
+            	}
+            }
+        }
+        return false;
+    }
+
+	@Override
+	public String getFunctionSignatureString() {
+		return "firstElement(string)string";
+	}
+
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/Index.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/Index.java
@@ -21,6 +21,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.reasoner.rulesys.RuleContext;
+import org.apache.jena.reasoner.rulesys.Util;
 import org.apache.jena.util.iterator.ClosableIterator;
 import org.apache.jena.util.iterator.ExtendedIterator;
 
@@ -61,32 +62,61 @@ public class Index extends TypedBaseBuiltin {
      */
     public boolean bodyCall(Node[] args, int length, RuleContext context) {
         Node typedList = getArg(0, args, context);
+        Node matchElement = getArg(1, args, context);
+        int index = 0;
         Node slmfirst = NodeFactory.createURI("http://sadl.org/sadllistmodel#first");
-        ClosableIterator<Triple> itr = context.find(typedList, slmfirst, null);
-        if (itr.hasNext()) {
-        	Node firstElement = itr.next().getObject();
-        	if (firstElement != null) {
-        		return context.getEnv().bind(args[length - 1], firstElement);	     
-        	}
+        Node slmrest = NodeFactory.createURI("http://sadl.org/sadllistmodel#rest");
+        
+        Node relevantList = typedList;
+        
+        boolean atMatchingElement = false;
+        do {
+            ClosableIterator<Triple> itr = context.find(relevantList, slmfirst, null);
+            if (itr.hasNext()) {
+            	Node firstElement = itr.next().getObject();
+            	if (firstElement != null && firstElement.equals(matchElement)) {
+            		itr.close();
+            		atMatchingElement = true;
+             	}
+            }
+            if (!atMatchingElement) {
+		        ClosableIterator<Triple> ritr = context.find(relevantList, slmrest, null);
+		        if (ritr.hasNext()) {
+		        	relevantList = ritr.next().getObject();
+			        index++;
+		        }
+		        else {
+		        	relevantList = null;
+		        }
+		        ritr.close();
+            }
+        } while (!atMatchingElement && relevantList != null);
+        
+        if (atMatchingElement) {
+        	Node indexNode = Util.makeIntNode(index);
+    		return context.getEnv().bind(args[length - 1], indexNode);	     
         }
-        else {
-            ClosableIterator<Triple> itr2 = context.find(typedList, null, null);
-            if (itr2.hasNext()) {
+        boolean debug = true;
+		if (debug) {
+	        ClosableIterator<Triple> itr2 = context.find(typedList, null, null);
+	        if (itr2.hasNext()) {
 	            while (itr2.hasNext()) {
 	            	System.out.println(itr2.next().toString());
 	            }
-            }
-            else {
-            	ExtendedIterator<Triple> itr3 = context.getGraph().find();
-            	if (itr3.hasNext()) {
+	        }
+	        else {
+	        	ExtendedIterator<Triple> itr3 = context.getGraph().find();
+	        	if (itr3.hasNext()) {
 	            	while (itr3.hasNext()) {
 	            		System.out.println(itr3.next().toString());
 	            	}
-            	}
-            	else {
-            		System.out.println(context.getGraph().toString());
-            	}
-            }
+	        	}
+	        	else {
+	        		System.out.println(context.getGraph().toString());
+	        	}
+	        	itr3.close();
+	        }
+	        itr2.close();
         }
         return false;
     }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/Index.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/Index.java
@@ -1,0 +1,100 @@
+/************************************************************************
+ * Copyright © 2021 - Natural Semantics, LLC. All Rights Reserved.
+ *
+ * Project: SADL
+ *
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ *
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ ***********************************************************************/
+package com.naturalsemantics.sadl.jena.reasoner.builtin;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.reasoner.rulesys.RuleContext;
+import org.apache.jena.util.iterator.ClosableIterator;
+import org.apache.jena.util.iterator.ExtendedIterator;
+
+import com.ge.research.sadl.jena.reasoner.builtin.TypedBaseBuiltin;
+
+/**
+ * This class implements a Jena Built-in function in the bodyCall method that takes a SADL typed 
+ * list and an element of that list as arguments and binds the index of the given list element, 
+ * if such exists, to the 3rd argument. If successful, the method returns true
+ * else it returns false.
+ * @author andy@naturalsemantics.com
+ */
+public class Index extends TypedBaseBuiltin {
+
+	private int argLength = 3;
+	
+	@Override
+	public String getName() {
+		return "index";
+	}
+
+    /**
+     * Return the expected number of arguments for this functor or 0 if the number is flexible.
+     */
+    public int getArgLength() {
+        return argLength;
+    }
+
+    /**
+     * This method is invoked when the builtin is called in a rule body.
+     * @param args the array of argument values for the builtin, this is an array 
+     * of Nodes, some of which may be Node_RuleVariables.
+     * @param length the length of the argument list, may be less than the length of the args array
+     * for some rule engines
+     * @param context an execution context giving access to other relevant data
+     * @return return true if the buildin predicate is deemed to have succeeded in
+     * the current environment
+     */
+    public boolean bodyCall(Node[] args, int length, RuleContext context) {
+        Node typedList = getArg(0, args, context);
+        Node slmfirst = NodeFactory.createURI("http://sadl.org/sadllistmodel#first");
+        ClosableIterator<Triple> itr = context.find(typedList, slmfirst, null);
+        if (itr.hasNext()) {
+        	Node firstElement = itr.next().getObject();
+        	if (firstElement != null) {
+        		return context.getEnv().bind(args[length - 1], firstElement);	     
+        	}
+        }
+        else {
+            ClosableIterator<Triple> itr2 = context.find(typedList, null, null);
+            if (itr2.hasNext()) {
+	            while (itr2.hasNext()) {
+	            	System.out.println(itr2.next().toString());
+	            }
+            }
+            else {
+            	ExtendedIterator<Triple> itr3 = context.getGraph().find();
+            	if (itr3.hasNext()) {
+	            	while (itr3.hasNext()) {
+	            		System.out.println(itr3.next().toString());
+	            	}
+            	}
+            	else {
+            		System.out.println(context.getGraph().toString());
+            	}
+            }
+        }
+        return false;
+    }
+
+	@Override
+	public String getFunctionSignatureString() {
+		return "index(string, string)int";
+	}
+
+
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/LastElement.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/LastElement.java
@@ -61,14 +61,32 @@ public class LastElement extends TypedBaseBuiltin {
     public boolean bodyCall(Node[] args, int length, RuleContext context) {
         Node typedList = getArg(0, args, context);
         Node slmfirst = NodeFactory.createURI("http://sadl.org/sadllistmodel#first");
-        ClosableIterator<Triple> itr = context.find(typedList, slmfirst, null);
+        Node slmrest = NodeFactory.createURI("http://sadl.org/sadllistmodel#rest");
+        
+        Node relevantList = typedList;
+        
+        boolean atLastElement = false;
+        do {
+	        ClosableIterator<Triple> ritr = context.find(relevantList, slmrest, null);
+	        if (ritr.hasNext()) {
+	        	relevantList = ritr.next().getObject();
+	        }
+	        else {
+	        	atLastElement = true;
+	        }
+	        ritr.close();
+        } while (!atLastElement);
+        
+        ClosableIterator<Triple> itr = context.find(relevantList, slmfirst, null);
         if (itr.hasNext()) {
         	Node firstElement = itr.next().getObject();
         	if (firstElement != null) {
+        		itr.close();
         		return context.getEnv().bind(args[length - 1], firstElement);	     
         	}
         }
-        else {
+        boolean debug = true;;
+		if (debug ) {
             ClosableIterator<Triple> itr2 = context.find(typedList, null, null);
             if (itr2.hasNext()) {
 	            while (itr2.hasNext()) {
@@ -85,7 +103,9 @@ public class LastElement extends TypedBaseBuiltin {
             	else {
             		System.out.println(context.getGraph().toString());
             	}
+            	itr3.close();
             }
+            itr2.close();
         }
         return false;
     }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/LastElement.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/LastElement.java
@@ -1,0 +1,99 @@
+/************************************************************************
+ * Copyright © 2021 - Natural Semantics, LLC. All Rights Reserved.
+ *
+ * Project: SADL
+ *
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ *
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ ***********************************************************************/
+package com.naturalsemantics.sadl.jena.reasoner.builtin;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.reasoner.rulesys.RuleContext;
+import org.apache.jena.util.iterator.ClosableIterator;
+import org.apache.jena.util.iterator.ExtendedIterator;
+
+import com.ge.research.sadl.jena.reasoner.builtin.TypedBaseBuiltin;
+
+/**
+ * This class implements a Jena Built-in function in the bodyCall method that takes a SADL typed 
+ * list as input argument and binds the last list element, if such exists, to the 2nd argument. 
+ * If successful, the method returns true else it returns false.
+ * @author andy@naturalsemantics.com
+ */
+public class LastElement extends TypedBaseBuiltin {
+
+	private int argLength = 2;
+	
+	@Override
+	public String getName() {
+		return "lastElement";
+	}
+
+    /**
+     * Return the expected number of arguments for this functor or 0 if the number is flexible.
+     */
+    public int getArgLength() {
+        return argLength;
+    }
+
+    /**
+     * This method is invoked when the builtin is called in a rule body.
+     * @param args the array of argument values for the builtin, this is an array 
+     * of Nodes, some of which may be Node_RuleVariables.
+     * @param length the length of the argument list, may be less than the length of the args array
+     * for some rule engines
+     * @param context an execution context giving access to other relevant data
+     * @return return true if the buildin predicate is deemed to have succeeded in
+     * the current environment
+     */
+    public boolean bodyCall(Node[] args, int length, RuleContext context) {
+        Node typedList = getArg(0, args, context);
+        Node slmfirst = NodeFactory.createURI("http://sadl.org/sadllistmodel#first");
+        ClosableIterator<Triple> itr = context.find(typedList, slmfirst, null);
+        if (itr.hasNext()) {
+        	Node firstElement = itr.next().getObject();
+        	if (firstElement != null) {
+        		return context.getEnv().bind(args[length - 1], firstElement);	     
+        	}
+        }
+        else {
+            ClosableIterator<Triple> itr2 = context.find(typedList, null, null);
+            if (itr2.hasNext()) {
+	            while (itr2.hasNext()) {
+	            	System.out.println(itr2.next().toString());
+	            }
+            }
+            else {
+            	ExtendedIterator<Triple> itr3 = context.getGraph().find();
+            	if (itr3.hasNext()) {
+	            	while (itr3.hasNext()) {
+	            		System.out.println(itr3.next().toString());
+	            	}
+            	}
+            	else {
+            		System.out.println(context.getGraph().toString());
+            	}
+            }
+        }
+        return false;
+    }
+
+	@Override
+	public String getFunctionSignatureString() {
+		return "lastElement(string)string";
+	}
+
+
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/Length.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/Length.java
@@ -1,0 +1,98 @@
+/************************************************************************
+ * Copyright © 2021 - Natural Semantics, LLC. All Rights Reserved.
+ *
+ * Project: SADL
+ *
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ *
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ *
+ ***********************************************************************/
+package com.naturalsemantics.sadl.jena.reasoner.builtin;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.reasoner.rulesys.RuleContext;
+import org.apache.jena.util.iterator.ClosableIterator;
+import org.apache.jena.util.iterator.ExtendedIterator;
+
+import com.ge.research.sadl.jena.reasoner.builtin.TypedBaseBuiltin;
+
+/**
+ * This class implements a Jena Built-in function in the bodyCall method that takes a SADL typed 
+ * list as input argument and binds the length of the list to the 2nd argument. 
+ * If successful, the method returns true else it returns false.
+ * @author andy@naturalsemantics.com
+ */
+public class Length extends TypedBaseBuiltin {
+
+	private int argLength = 2;
+	
+	@Override
+	public String getName() {
+		return "length";
+	}
+
+    /**
+     * Return the expected number of arguments for this functor or 0 if the number is flexible.
+     */
+    public int getArgLength() {
+        return argLength;
+    }
+
+    /**
+     * This method is invoked when the builtin is called in a rule body.
+     * @param args the array of argument values for the builtin, this is an array 
+     * of Nodes, some of which may be Node_RuleVariables.
+     * @param length the length of the argument list, may be less than the length of the args array
+     * for some rule engines
+     * @param context an execution context giving access to other relevant data
+     * @return return true if the buildin predicate is deemed to have succeeded in
+     * the current environment
+     */
+    public boolean bodyCall(Node[] args, int length, RuleContext context) {
+        Node typedList = getArg(0, args, context);
+        Node slmfirst = NodeFactory.createURI("http://sadl.org/sadllistmodel#first");
+        ClosableIterator<Triple> itr = context.find(typedList, slmfirst, null);
+        if (itr.hasNext()) {
+        	Node firstElement = itr.next().getObject();
+        	if (firstElement != null) {
+        		return context.getEnv().bind(args[length - 1], firstElement);	     
+        	}
+        }
+        else {
+            ClosableIterator<Triple> itr2 = context.find(typedList, null, null);
+            if (itr2.hasNext()) {
+	            while (itr2.hasNext()) {
+	            	System.out.println(itr2.next().toString());
+	            }
+            }
+            else {
+            	ExtendedIterator<Triple> itr3 = context.getGraph().find();
+            	if (itr3.hasNext()) {
+	            	while (itr3.hasNext()) {
+	            		System.out.println(itr3.next().toString());
+	            	}
+            	}
+            	else {
+            		System.out.println(context.getGraph().toString());
+            	}
+            }
+        }
+        return false;
+    }
+
+	@Override
+	public String getFunctionSignatureString() {
+		return "length(string)int";
+	}
+
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/Length.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemantics/sadl/jena/reasoner/builtin/Length.java
@@ -21,6 +21,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.reasoner.rulesys.RuleContext;
+import org.apache.jena.reasoner.rulesys.Util;
 import org.apache.jena.util.iterator.ClosableIterator;
 import org.apache.jena.util.iterator.ExtendedIterator;
 
@@ -60,34 +61,26 @@ public class Length extends TypedBaseBuiltin {
      */
     public boolean bodyCall(Node[] args, int length, RuleContext context) {
         Node typedList = getArg(0, args, context);
-        Node slmfirst = NodeFactory.createURI("http://sadl.org/sadllistmodel#first");
-        ClosableIterator<Triple> itr = context.find(typedList, slmfirst, null);
-        if (itr.hasNext()) {
-        	Node firstElement = itr.next().getObject();
-        	if (firstElement != null) {
-        		return context.getEnv().bind(args[length - 1], firstElement);	     
-        	}
-        }
-        else {
-            ClosableIterator<Triple> itr2 = context.find(typedList, null, null);
-            if (itr2.hasNext()) {
-	            while (itr2.hasNext()) {
-	            	System.out.println(itr2.next().toString());
-	            }
-            }
-            else {
-            	ExtendedIterator<Triple> itr3 = context.getGraph().find();
-            	if (itr3.hasNext()) {
-	            	while (itr3.hasNext()) {
-	            		System.out.println(itr3.next().toString());
-	            	}
-            	}
-            	else {
-            		System.out.println(context.getGraph().toString());
-            	}
-            }
-        }
-        return false;
+        Node slmrest = NodeFactory.createURI("http://sadl.org/sadllistmodel#rest");
+        
+        Node relevantList = typedList;
+        
+        int listLength = 1;
+        boolean atLastElement = false;
+        do {
+	        ClosableIterator<Triple> ritr = context.find(relevantList, slmrest, null);
+	        if (ritr.hasNext()) {
+	        	relevantList = ritr.next().getObject();
+	        	listLength++;
+	        }
+	        else {
+	        	atLastElement = true;
+	        }
+	        ritr.close();
+        } while (!atLastElement);
+        
+    	Node lengthNode = Util.makeIntNode(listLength);
+		return context.getEnv().bind(args[length - 1], lengthNode);	     
     }
 
 	@Override

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/IntermediateFormTranslator.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/IntermediateFormTranslator.java
@@ -4869,8 +4869,9 @@ public class IntermediateFormTranslator implements I_IntermediateFormTranslator 
 	 * information in the original NamedNode from the Jena OntModel Resource.
 	 * @param theNode
 	 * @return
+	 * @throws TranslationException 
 	 */
-	public Resource getResourceFromNamedNode(NamedNode theNode) {
+	public Resource getResourceFromNamedNode(NamedNode theNode) throws TranslationException {
 		Resource rsrc = null;
 		if(theNode == null) {
 			return null;

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
@@ -5674,26 +5674,26 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 	protected Object processBinaryExpressionByParts(EObject container, String op, Expression lexpr, Expression rexpr)
 			throws InvalidNameException, InvalidTypeException, TranslationException {
 		StringBuilder errorMessage = new StringBuilder();
-//		if (!op.equals("and") && !op.equals("or")) {
-//			// don't validate these as they will be validated in their parts and to do so now will not always work
-			if (lexpr != null && rexpr != null) {
-				if(!isDeclaration(lexpr, rexpr, op) && 
-						!getModelValidator().validateBinaryOperationByParts(container, lexpr, rexpr, op, errorMessage, false)){
-					addTypeCheckingError(errorMessage.toString(), container);
-				}
-				else {
-					Map<EObject, Property> ip = getModelValidator().getImpliedPropertiesUsed();
-					if (ip != null) {
-						Iterator<EObject> ipitr = ip.keySet().iterator();
-						while (ipitr.hasNext()) {
-							EObject eobj = ipitr.next();
-							OntModelProvider.addImpliedProperty(lexpr.eResource(), eobj, ip.get(eobj));
-						}
-						// TODO must add implied properties to rules, tests, etc.
+		boolean isDefiningDeclaration = false;
+		if (lexpr != null && rexpr != null) {
+			isDefiningDeclaration = isDefiningDeclaration(lexpr, rexpr, op);
+			// no need to do type checking if this is a defining declaration
+			if(!isDefiningDeclaration && 
+					!getModelValidator().validateBinaryOperationByParts(container, lexpr, rexpr, op, errorMessage, false)){
+				addTypeCheckingError(errorMessage.toString(), container);
+			}
+			else {
+				Map<EObject, Property> ip = getModelValidator().getImpliedPropertiesUsed();
+				if (ip != null) {
+					Iterator<EObject> ipitr = ip.keySet().iterator();
+					while (ipitr.hasNext()) {
+						EObject eobj = ipitr.next();
+						OntModelProvider.addImpliedProperty(lexpr.eResource(), eobj, ip.get(eobj));
 					}
+					// TODO must add implied properties to rules, tests, etc.
 				}
 			}
-//		}
+		}
 		BuiltinType optype = BuiltinType.getType(op);
 		Object lobj = null;
 		if (lexpr != null) {
@@ -5869,6 +5869,9 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 					// this is a Declaration with a variable on the right and an individual on the left
 					TripleElement trel = new TripleElement((Node) lobj, new RDFTypeNode(), (Node) robj);
 					trel.setSourceType(TripleSourceType.ITC);
+					if (isDefiningDeclaration) {
+						trel.setObject(((VariableNode)robj).getType());
+					}
 					return applyImpliedAndExpandedProperties(container, lexpr, rexpr, trel);
 				}
 				else if (!(robj instanceof VariableNode)) {
@@ -6272,7 +6275,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 		}
 	}
 
-	private boolean isDeclaration(Expression lexpr, Expression rexpr, String op) {
+	private boolean isDefiningDeclaration(Expression lexpr, Expression rexpr, String op) {
 		if (op.equals("is") && lexpr instanceof Name && 
 				declarationExtensions.getDeclaration(((Name)lexpr).getName().getName()).equals(((Name)lexpr).getName()) &&
 				lexpr.eContainer().equals(rexpr.eContainer())) {
@@ -7892,9 +7895,12 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 		return false;
 	}
 
-	public boolean isProperty(Object node) {
+	public boolean isProperty(Object node) throws TranslationException {
 		if (node instanceof NamedNode) {
 			return isProperty(((NamedNode) node).getNodeType());
+		}
+		else if (node instanceof ConceptName) {
+			return isProperty(conceptTypeToNodeType(((ConceptName)node).getType()));
 		}
 		return false;
 	}
@@ -15690,7 +15696,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 		return false;
 	}
 
-	private List<TripleElement> getTriplesOfInterestList(List<TripleElement> found, GraphPatternElement gpe) throws InvalidTypeException {
+	private List<TripleElement> getTriplesOfInterestList(List<TripleElement> found, GraphPatternElement gpe) throws InvalidTypeException, TranslationException {
 		if (gpe instanceof TripleElement) {
 			if (((TripleElement)gpe).getSubject() != null) {
 				found = addTripleElement(found, (TripleElement)gpe);
@@ -15724,7 +15730,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 		return found;
 	}
 
-	private List<TripleElement> addTripleOfInterest(List<TripleElement> found, Node node) throws InvalidTypeException {
+	private List<TripleElement> addTripleOfInterest(List<TripleElement> found, Node node) throws InvalidTypeException, TranslationException {
 		if (node instanceof NamedNode && !(node instanceof VariableNode)) {
 			if (isProperty((NamedNode)node)) {
 				TripleElement newtr = new TripleElement(null, node, null);

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
@@ -5677,7 +5677,8 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 //		if (!op.equals("and") && !op.equals("or")) {
 //			// don't validate these as they will be validated in their parts and to do so now will not always work
 			if (lexpr != null && rexpr != null) {
-				if(!getModelValidator().validateBinaryOperationByParts(container, lexpr, rexpr, op, errorMessage, false)){
+				if(!isDeclaration(lexpr, rexpr, op) && 
+						!getModelValidator().validateBinaryOperationByParts(container, lexpr, rexpr, op, errorMessage, false)){
 					addTypeCheckingError(errorMessage.toString(), container);
 				}
 				else {
@@ -6269,6 +6270,15 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 			}
 			return combineRest(applyImpliedAndExpandedProperties(container, lexpr, rexpr, bi), rest);
 		}
+	}
+
+	private boolean isDeclaration(Expression lexpr, Expression rexpr, String op) {
+		if (op.equals("is") && lexpr instanceof Name && 
+				declarationExtensions.getDeclaration(((Name)lexpr).getName().getName()).equals(((Name)lexpr).getName()) &&
+				lexpr.eContainer().equals(rexpr.eContainer())) {
+			return true;
+		}
+		return false;
 	}
 
 	private void applyRestrictionToVariableType(VariableNode vobj, NamedNode restrictionType, EObject expr) throws CircularDependencyException, TranslationException {
@@ -7689,7 +7699,8 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 					if (expr.eContainer() instanceof BinaryOperation &&
 							((BinaryOperation)expr.eContainer()).getOp().equals("is") &&
 							typenode instanceof NamedNode && 
-							((NamedNode)typenode).getNodeType().equals(NodeType.ClassNode) &&
+							(((NamedNode)typenode).getNodeType().equals(NodeType.ClassNode) ||
+									((NamedNode)typenode).getNodeType().equals(NodeType.ClassListNode)) &&
 							((BinaryOperation)expr.eContainer()).getLeft() instanceof Name &&
 							(getDeclarationExtensions().getOntConceptType(((Name)((BinaryOperation)expr.eContainer()).getLeft())).equals(OntConceptType.INSTANCE) ||
 							getDeclarationExtensions().getOntConceptType(((Name)((BinaryOperation)expr.eContainer()).getLeft())).equals(OntConceptType.VARIABLE))) {

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/UtilsForJena.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/UtilsForJena.java
@@ -409,16 +409,16 @@ public class UtilsForJena {
 						if (avfstmt != null) {
 							type = avfstmt.getObject();
 							if (type.isURIResource()) {
-								tctypetype = NodeType.ClassListNode;
+								tctypetype = NodeType.ClassNode;
 								if (type.asResource().getNameSpace().equals(XSD.getURI())) {
-									tctypetype = NodeType.DataTypeListNode;
+									tctypetype = NodeType.DataTypeNode;
 								}
 								else {
 									StmtIterator eqitr = type.asResource().listProperties(OWL.equivalentClass);
 									if (eqitr.hasNext()) {
 										RDFNode eqCls = eqitr.nextStatement().getObject();
 										if (eqCls.equals(RDFS.Datatype)) {
-											tctypetype = NodeType.DataTypeListNode;
+											tctypetype = NodeType.DataTypeNode;
 										}
 									}
 								}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/missingpatterns/PathFinder.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/missingpatterns/PathFinder.java
@@ -767,9 +767,10 @@ public class PathFinder {
 	 * @param nodesReached 
 	 * @param notSolved
 	 * @return
+	 * @throws TranslationException 
 	 */
 	private List<Resource> getNewEffectiveRoots(List<Resource> roots, List<Resource> newEffectiveRoots, List<Resource> ceilingNodes,
-			List<Resource> solved, Map<Resource, Map<Resource, List<DirectedPath>>> nodesReached) {
+			List<Resource> solved, Map<Resource, Map<Resource, List<DirectedPath>>> nodesReached) throws TranslationException {
 		boolean allRootsConnected = true;
 		
 		// Identify a target to serve as a test node against which all other roots are checked for paths to determine if solution is complete
@@ -1517,8 +1518,9 @@ public class PathFinder {
 	 * Method to determine if a Node is a property in the ontology
 	 * @param nodeType
 	 * @return
+	 * @throws TranslationException 
 	 */
-	protected boolean isProperty(Node nodeType) {
+	protected boolean isProperty(Node nodeType) throws TranslationException {
 		return getIftranslator().getModelProcessor().isProperty(nodeType);
 	}
 

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-api/src/main/java/com/ge/research/sadl/model/gp/NamedNode.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-api/src/main/java/com/ge/research/sadl/model/gp/NamedNode.java
@@ -188,7 +188,7 @@ public class NamedNode extends Node {
 		sb.append(name);
 		if (getNodeType() != null && 
 				(getNodeType().equals(NodeType.ClassListNode) || getNodeType().equals(NodeType.DataTypeListNode))) {
-			sb.append(" List");
+			sb.append(" (List)");
 			if(listLiterals != null) {
 				sb.append(" [");
 				for(int i = 0; i < listLiterals.size(); i++) {

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/model/SadlModelProcessorTypeCheckingTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/model/SadlModelProcessorTypeCheckingTest.xtend
@@ -578,6 +578,83 @@ class SadlModelProcessorTypeCheckingTest extends AbstractSADLModelProcessorTest 
 	}
 	
 	@Test
+	def void testListBuiltins_01() {
+		'''
+		  uri "http://sadl.org/UsingListExpression.sadl" alias UsingListExpression.
+		  
+		  YooHoo is a class.
+		  YooHooList is a type of YooHoo List, described by selectedElement with values of type YooHoo.
+		  l1 is the YooHooList [yh1, yh2, yh3, yh4].
+		  
+		  Rule ListFirst:
+		    if l1 is a YooHooList and 
+		    		first element of l1 is le1 then l1 has selectedElement le1 and print("ListFirst: ", le1).
+		    		
+		  Rule ListLast:
+		  	if l1 is a YooHooList and last element of l1 is lel then print("Last element of l1: ", lel).   	
+		  	
+		  Rule ListAfter:
+		  	if l1 is a YooHooList and element after yh2 in l1 is lea then print("Element after yh2: ", lea). 
+		    
+		  Rule ListBefore:
+		  	if l1 is a YooHooList and element before yh3 in l1 is leb then print("Element before yh3: ", leb). 
+		 
+		  Rule ListElementAt:
+		  	if l1 is a YooHooList and element 3 of l1 is le3 then print("Element 3: ", le3). 
+		 
+		  Rule ListIndex:
+		  	if l1 is a YooHooList and index of yh2 in l1 is idx then print("Index of yh2: ", idx). 
+		  	
+		  Rule ListLength:
+		  	if l1 is a YooHooList and len is length of l1 then print("Length of l1: ", len).
+		 '''.assertValidatesTo[ jenaModel, rules, cmds, issues, processor |
+			assertNotNull(jenaModel)
+			if (issues !== null) {
+				for (issue : issues) {
+					System.out.println(issue.message)
+				}
+			}
+			if (rules !== null) {
+				for (rule : rules) {
+					System.out.println(rule.toString)
+				}
+			}
+			assertTrue(issues.size == 0)
+			assertTrue(rules.size == 7)
+			assertTrue(
+				processor.compareTranslations(rules.get(0).toString(),
+					'Rule ListFirst:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and firstElement(UsingListExpression:l1,le1) then rdf(UsingListExpression:l1, UsingListExpression:selectedElement, le1) and print("ListFirst: ",le1).'))
+			assertTrue(
+				processor.compareTranslations(rules.get(1).toString(),
+					'Rule ListLast:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and lastElement(UsingListExpression:l1,lel) then print("Last element of l1: ",lel).'))
+			assertTrue(
+				processor.compareTranslations(rules.get(2).toString(),
+					'Rule ListAfter:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and elementAfter(UsingListExpression:l1,UsingListExpression:yh2,lea) then print("Element after yh2: ",lea).'))
+			assertTrue(
+				processor.compareTranslations(rules.get(3).toString(),
+					'Rule ListBefore:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and elementBefore(UsingListExpression:l1,UsingListExpression:yh3,leb) then print("Element before yh3: ",leb).'))
+			assertTrue(
+				processor.compareTranslations(rules.get(4).toString(),
+					'Rule ListElementAt:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and elementInList(UsingListExpression:l1,3,le3) then print("Element 3: ",le3).'))
+			assertTrue(
+				processor.compareTranslations(rules.get(5).toString(),
+					'Rule ListIndex:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and index(UsingListExpression:l1,UsingListExpression:yh2,idx) then print("Index of yh2: ",idx).'))
+			assertTrue(
+				processor.compareTranslations(rules.get(6).toString(),
+					'Rule ListLength:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and length(UsingListExpression:l1,len) then print("Length of l1: ",len).'))
+		]
+/*
+Rule ListFirst:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and firstElement(UsingListExpression:l1,le1) then rdf(UsingListExpression:l1, UsingListExpression:selectedElement, le1) and print("ListFirst: ",le1).
+Rule ListLast:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and lastElement(UsingListExpression:l1,lel) then print("Last element of l1: ",lel).
+Rule ListAfter:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and elementAfter(UsingListExpression:l1,UsingListExpression:yh2,lea) then print("Element after yh2: ",lea).
+Rule ListBefore:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and elementBefore(UsingListExpression:l1,UsingListExpression:yh3,leb) then print("Element before yh3: ",leb).
+Rule ListElementAt:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and elementInList(UsingListExpression:l1,3,le3) then print("Element 3: ",le3).
+Rule ListIndex:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and index(UsingListExpression:l1,UsingListExpression:yh2,idx) then print("Index of yh2: ",idx).
+Rule ListLength:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and length(UsingListExpression:l1,len) then print("Length of l1: ",len).
+		*/
+	}
+	
+	@Test
 	def void testIntersectionClass_01() {
 		val sadlModel = '''
 		 uri "http://sadl.org/NoList.sadl" alias nolist.

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/model/SadlModelProcessorTypeCheckingTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/model/SadlModelProcessorTypeCheckingTest.xtend
@@ -460,11 +460,11 @@ class SadlModelProcessorTypeCheckingTest extends AbstractSADLModelProcessorTest 
 			println(issue.message)
 		}
 		// expect error on last line as i5 could be a C
-		sadlModel.assertError("TypeCheckInfo(B List, range of property p), cannot be compared (is) with TypeCheckInfo(the List [TypeCheckInfo(i1 (type B and C),TypeCheckInfo(http://sadl.org/list.sadl#i2, B),TypeCheckInfo(http://sadl.org/list.sadl#i3, C)].")
+		sadlModel.assertError("TypeCheckInfo(B (List), type of an unnamed typed list class, range of property p), cannot be compared (is) with TypeCheckInfo(the List [TypeCheckInfo(i1 (type B and C),TypeCheckInfo(http://sadl.org/list.sadl#i2, B),TypeCheckInfo(http://sadl.org/list.sadl#i3, C)].")
 	}
 	
 	@Test
-	def void testTypeList_10() {
+	def void testTypedList_10() {
 		val sadlModel = '''
 		 uri "http://sadl.org/list.sadl" alias lst.
 		 
@@ -487,7 +487,7 @@ class SadlModelProcessorTypeCheckingTest extends AbstractSADLModelProcessorTest 
 			println(issue.message)
 		}
 		// expect error on last line as i5 could be a C
-		sadlModel.assertError("TypeCheckInfo(B List, range of property p), cannot be compared (is) with TypeCheckInfo(the List [TypeCheckInfo(i5 (type B or C)].")
+		sadlModel.assertError("TypeCheckInfo(B (List), type of an unnamed typed list class, range of property p), cannot be compared (is) with TypeCheckInfo(the List [TypeCheckInfo(i5 (type B or C)].")
 	}
 
 	@Test
@@ -515,7 +515,7 @@ class SadlModelProcessorTypeCheckingTest extends AbstractSADLModelProcessorTest 
 			assertTrue(rules.size == 1)
 			assertTrue(
 				processor.compareTranslations(rules.get(0).toString(),
-					"Rule ListFirst:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHoo List) and firstElement(UsingListExpression:l1,le1) then print(le1)."))
+					"Rule ListFirst:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHoo (List)) and firstElement(UsingListExpression:l1,le1) then print(le1)."))
 		]
 	}
 	
@@ -569,11 +569,11 @@ class SadlModelProcessorTypeCheckingTest extends AbstractSADLModelProcessorTest 
 					System.out.println(rule.toString)
 				}
 			}
-			assertTrue(issues.size == 4)	// content requires articles to be enabled, 2 var not bound in premises
+			assertTrue(issues.size == 0)
 			assertTrue(rules.size == 1)
 			assertTrue(
 				processor.compareTranslations(rules.get(0).toString(),
-					"Rule ListFirst:  if rdf(UsingListExpression:l1, rdf:type, v0) and firstElement(UsingListExpression:l1,le1) then rdf(UsingListExpression:l1, UsingListExpression:selectedElement, le1) and print(le1)."))
+					"Rule ListFirst:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHooList (List)) and firstElement(UsingListExpression:l1,le1) then rdf(UsingListExpression:l1, UsingListExpression:selectedElement, le1) and print(le1)."))
 		]
 	}
 	

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/model/SadlModelProcessorTypeCheckingTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/model/SadlModelProcessorTypeCheckingTest.xtend
@@ -19,6 +19,8 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertTrue
 import com.google.common.collect.Iterables
 
 @RunWith(XtextRunner)
@@ -343,7 +345,42 @@ class SadlModelProcessorTypeCheckingTest extends AbstractSADLModelProcessorTest 
 	}
 	
 	@Test
+	def void testTypedList_00() {
+		'''
+		 uri "http://sadl.org/UsingListExpression.sadl" alias UsingListExpression.
+		 YooHoo is a class.
+		 l1 is the YooHoo List [yh1, yh2, yh3, yh4].
+		 '''.assertValidatesTo[ jenaModel, rules, cmds, issues, processor |
+			assertNotNull(jenaModel)
+			if (issues !== null) {
+				for (issue : issues) {
+					System.out.println(issue.message)
+				}
+			}
+			assertTrue(issues.size == 0)
+		]
+	}
+	
+	@Test
 	def void testTypedList_01() {
+		'''
+		 uri "http://sadl.org/UsingListExpression.sadl" alias UsingListExpression.
+		 YooHoo is a class.
+		 YooHooList is a type of YooHoo List, described by selectedElement with values of type YooHoo.
+		 l1 is the YooHooList [yh1, yh2, yh3, yh4].
+		 '''.assertValidatesTo[ jenaModel, rules, cmds, issues, processor |
+			assertNotNull(jenaModel)
+			if (issues !== null) {
+				for (issue : issues) {
+					System.out.println(issue.message)
+				}
+			}
+			assertTrue(issues.size == 0)	// content requires articles to be enabled, 2 var not bound in premises
+		]
+	}
+	
+	@Test
+	def void testTypedList_06() {
 		val sadlModel = '''
 		uri "http://sadl.org/list.sadl3" alias lst3.
 		
@@ -363,7 +400,7 @@ class SadlModelProcessorTypeCheckingTest extends AbstractSADLModelProcessorTest 
 	}
 	
 	@Test
-	def void testTypedList02() {
+	def void testTypedList_07() {
 		val sadlModel = '''
 			 uri "http://sadl.org/list.sadl" alias lst.
 			 
@@ -383,7 +420,7 @@ class SadlModelProcessorTypeCheckingTest extends AbstractSADLModelProcessorTest 
 	}
 	
 	@Test
-	def void testTypedList03() {
+	def void testTypedList_08() {
 		val sadlModel = '''
 			 uri "http://sadl.org/list.sadl" alias lst.
 			 
@@ -404,7 +441,7 @@ class SadlModelProcessorTypeCheckingTest extends AbstractSADLModelProcessorTest 
 	}
 	
 	@Test
-	def void testTypedList04() {
+	def void testTypedList_09() {
 		val sadlModel = '''
 			 uri "http://sadl.org/list.sadl" alias lst.
 			 
@@ -453,6 +490,93 @@ class SadlModelProcessorTypeCheckingTest extends AbstractSADLModelProcessorTest 
 		sadlModel.assertError("TypeCheckInfo(B List, range of property p), cannot be compared (is) with TypeCheckInfo(the List [TypeCheckInfo(i5 (type B or C)].")
 	}
 
+	@Test
+	def void testFirstElement_01() {
+		'''
+		 uri "http://sadl.org/UsingListExpression.sadl" alias UsingListExpression.
+		 YooHoo is a class.
+		 l1 is the YooHoo List [yh1, yh2, yh3, yh4].
+		 Rule ListFirst:
+		   if l1 is a YooHoo List and 
+		   		first element of l1 is le1 then print(le1).
+		 '''.assertValidatesTo[ jenaModel, rules, cmds, issues, processor |
+			assertNotNull(jenaModel)
+			if (issues !== null) {
+				for (issue : issues) {
+					System.out.println(issue.message)
+				}
+			}
+			if (rules !== null) {
+				for (rule : rules) {
+					System.out.println(rule.toString)
+				}
+			}
+			assertTrue(issues.size == 0)	
+			assertTrue(rules.size == 1)
+			assertTrue(
+				processor.compareTranslations(rules.get(0).toString(),
+					"Rule ListFirst:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHoo List) and firstElement(UsingListExpression:l1,le1) then print(le1)."))
+		]
+	}
+	
+	@Test
+	def void testFirstElement_01Compare() {
+		'''
+		 uri "http://sadl.org/UsingListExpression.sadl" alias UsingListExpression.
+		 YooHoo is a class.
+		 l1 is the YooHoo.
+		 Rule ListFirst:
+		   if l1 is a YooHoo then print(l1).
+		 '''.assertValidatesTo[ jenaModel, rules, cmds, issues, processor |
+			assertNotNull(jenaModel)
+			if (issues !== null) {
+				for (issue : issues) {
+					System.out.println(issue.message)
+				}
+			}
+			if (rules !== null) {
+				for (rule : rules) {
+					System.out.println(rule.toString)
+				}
+			}
+			assertTrue(issues.size == 0)	
+			assertTrue(rules.size == 1)
+			assertTrue(
+				processor.compareTranslations(rules.get(0).toString(),
+					"Rule ListFirst:  if rdf(UsingListExpression:l1, rdf:type, UsingListExpression:YooHoo) then print(UsingListExpression:l1)."))
+		]
+	}
+
+	@Test
+	def void testFirstElement_02() {
+		'''
+		 uri "http://sadl.org/UsingListExpression.sadl" alias UsingListExpression.
+		 YooHoo is a class.
+		 YooHooList is a type of YooHoo List, described by selectedElement with values of type YooHoo.
+		 l1 is the YooHooList [yh1, yh2, yh3, yh4].
+		 Rule ListFirst:
+		   if l1 is a YooHooList and 
+		   		first element of l1 is le1 then l1 has selectedElement le1 and print(le1).
+		 '''.assertValidatesTo[ jenaModel, rules, cmds, issues, processor |
+			assertNotNull(jenaModel)
+			if (issues !== null) {
+				for (issue : issues) {
+					System.out.println(issue.message)
+				}
+			}
+			if (rules !== null) {
+				for (rule : rules) {
+					System.out.println(rule.toString)
+				}
+			}
+			assertTrue(issues.size == 4)	// content requires articles to be enabled, 2 var not bound in premises
+			assertTrue(rules.size == 1)
+			assertTrue(
+				processor.compareTranslations(rules.get(0).toString(),
+					"Rule ListFirst:  if rdf(UsingListExpression:l1, rdf:type, v0) and firstElement(UsingListExpression:l1,le1) then rdf(UsingListExpression:l1, UsingListExpression:selectedElement, le1) and print(le1)."))
+		]
+	}
+	
 	@Test
 	def void testIntersectionClass_01() {
 		val sadlModel = '''


### PR DESCRIPTION
Implementation of list built-ins supported by the SADL grammar: ElementAfter, ElementBefore, ElementInList, FirstElement, Index, LastElement, Length. The built-ins Index and ElementInList are currently 0-based.