### PR TITLE
Remove slf4j-log4j12 jar

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.jena/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.jena/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Jena 4 OSGi
+Bundle-Name: com.ge.research.jena
 Bundle-SymbolicName: com.ge.research.jena
 Bundle-Version: 3.5.0.qualifier
 Bundle-Vendor: GE Research

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/ExecuteCommand.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/ExecuteCommand.java
@@ -124,7 +124,7 @@ public class ExecuteCommand implements IApplication {
             return null;
         }
 
-        // Set Eclipse Preferences to compatible values for SADL CLI
+        // Set Eclipse preferences to compatible values for SADL CLI
         setEclipsePreferences();
 
         // Import project if not already part of workspace
@@ -155,9 +155,9 @@ public class ExecuteCommand implements IApplication {
             }
         }
 
-        // Restore Eclipse Preferences
+        // Restore Eclipse preferences and save
         restoreEclipsePreferences();
-        refreshWorkspace();
+        saveWorkspace();
 
         LOGGER.info("SADL Command-Line Interface complete");
 
@@ -277,10 +277,22 @@ public class ExecuteCommand implements IApplication {
         try {
             IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
             workspaceRoot.refreshLocal(IResource.DEPTH_INFINITE, null);
+            return true;
         } catch (CoreException e) {
             LOGGER.error("Error refreshing workspace: " + e);
+            return false;
         }
-        return true;
+    }
+
+    private boolean saveWorkspace() {
+        try {
+            IWorkspace workspace = ResourcesPlugin.getWorkspace();
+            workspace.save(true, null);
+            return true;
+        } catch (CoreException e) {
+            LOGGER.error("Error saving workspace: " + e);
+            return false;
+        }
     }
 
     private void setEclipsePreferences() {

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.errorgenerator/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.errorgenerator/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: ErrorGenerator
+Bundle-Name: com.ge.research.sadl.errorgenerator
 Bundle-SymbolicName: com.ge.research.sadl.errorgenerator
 Bundle-Version: 3.5.0.qualifier
 Bundle-Vendor: GE Research

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.externalmodels/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.externalmodels/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Externalmodels
+Bundle-Name: com.ge.research.sadl.externalmodels
 Bundle-SymbolicName: com.ge.research.sadl.externalmodels;singleton:=true
 Bundle-Version: 3.5.0.qualifier
 Bundle-Vendor: GE Research

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/pom.xml
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/pom.xml
@@ -75,10 +75,6 @@
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-tree</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Jena-plugin
+Bundle-Name: com.ge.research.sadl.jena-wrapper-for-sadl
 Bundle-SymbolicName: com.ge.research.sadl.jena-wrapper-for-sadl;singleton:=true
 Bundle-Version: 3.5.0.qualifier
 Bundle-Activator: com.ge.research.sadl.jena_plugin.Activator
@@ -40,9 +40,8 @@ Export-Package: com.ge.research.sadl.jena.importer,
    com.ge.research.sadl.reasoner,
    com.ge.research.sadl.model,
    org.apache.jena.ontology"
-Bundle-ClassPath: .
 Import-Package: com.ge.research.sadl.model,
  com.ge.research.sadl.model.gp,
  com.ge.research.sadl.reasoner,
  jakarta.activation
-Automatic-Module-Name: com.ge.research.sadl.jena-wrapper-for-sadl
+Automatic-Module-Name: com.ge.research.sadl.jena.wrapper.for.sadl

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Jena
+Bundle-Name: com.ge.research.sadl.jena
 Bundle-SymbolicName: com.ge.research.sadl.jena;singleton:=true
 Bundle-Version: 3.5.0.qualifier
 Bundle-Vendor: GE Research

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/pom.xml
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/pom.xml
@@ -12,15 +12,6 @@
   <artifactId>com.ge.research.sadl.jena</artifactId>
   <packaging>eclipse-plugin</packaging>
 
-  <!-- Needed by eu.somatik.serviceloader-maven-plugin -->
-  <dependencies>
-    <dependency>
-      <groupId>com.ge.research.sadl</groupId>
-      <artifactId>com.ge.research.sadl</artifactId>
-      <type>eclipse-plugin</type>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <!-- Generate META-INF/services/... -->
@@ -34,6 +25,14 @@
             <param>com.ge.research.sadl.processing.ISadlInferenceProcessor</param>
           </services>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.ge.research.sadl</groupId>
+            <artifactId>com.ge.research.sadl</artifactId>
+            <version>${version.sadl}</version>
+            <type>eclipse-plugin</type>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.perspective/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.perspective/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: SADL Perspective
+Bundle-Name: com.ge.research.sadl.perspective
 Bundle-SymbolicName: com.ge.research.sadl.perspective;singleton:=true
 Bundle-Version: 3.5.0.qualifier
 Bundle-Vendor: GE Research

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.swi-prolog-plugin/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.swi-prolog-plugin/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Swi-Prolog-Plugin
+Bundle-Name: com.ge.research.sadl.swi-prolog-plugin
 Bundle-SymbolicName: com.ge.research.sadl.swi-prolog-plugin;singleton:=true
 Bundle-Version: 3.5.0.qualifier
 Bundle-Activator: com.ge.research.sadl.swi_prolog.plugin.Activator
@@ -26,8 +26,6 @@ Export-Package: com.ge.research.sadl.swi_prolog.fileinterface,
    org.apache.jena.rdf.model,
    org.apache.jena.ontology",
  com.ge.research.sadl.swi_prolog.translator
-Bundle-ClassPath: .,
- target/classes/com/ge/research/sadl/swi-prolog/plinterface/
 Import-Package: com.ge.research.sadl.model,
  com.ge.research.sadl.model.gp,
  com.ge.research.sadl.reasoner,

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/pom.xml
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/pom.xml
@@ -17,7 +17,7 @@
     <!-- We use Maven Surefire instead of Tycho Surefire to run the tests outside of the OSGi container. -->
     <!-- Source: https://wiki.eclipse.org/Tycho/FAQ#Can_I_run_eclipse-plugin_tests_also_outside_an_OSGi_container.3F -->
     <!-- GH issue: https://github.com/crapo/sadlos2/issues/370 -->
-    <!-- Maven Surefire expects test classes in ${project.build.directory}/test-classes by default. -->
+    <!-- Surefire expects test classes in ${project.build.directory}/test-classes by default -->
     <testOutputDirectory>${project.build.directory}/classes</testOutputDirectory>
     <plugins>
       <!-- Make sure the tests run as Maven Surefire tests. -->
@@ -25,11 +25,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <dependencies>
-          <!-- Explicitly declare the Maven Surefire provider for JUnit4, see http://maven.apache.org/surefire/maven-surefire-plugin/examples/providers.html -->
+          <!-- Explicitly declare Surefire provider for JUnit4, see http://maven.apache.org/surefire/maven-surefire-plugin/examples/providers.html -->
           <dependency>
             <groupId>org.apache.maven.surefire</groupId>
             <artifactId>surefire-junit4</artifactId>
-            <version>3.0.0-M5</version>
+            <version>${version.surefire}</version>
           </dependency>
         </dependencies>
         <executions>

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/pom.xml
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/pom.xml
@@ -19,7 +19,6 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <configuration>
-          <failIfNoTests>false</failIfNoTests>
           <useUIHarness>true</useUIHarness>
         </configuration>
       </plugin>

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.xtextgenerator/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.xtextgenerator/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Xtextgenerator
+Bundle-Name: com.ge.research.sadl.xtextgenerator
 Bundle-SymbolicName: com.ge.research.sadl.xtextgenerator
 Bundle-Vendor: GE Research
 Bundle-Version: 3.5.0.qualifier

--- a/sadl3/com.ge.research.sadl.parent/pom.xml
+++ b/sadl3/com.ge.research.sadl.parent/pom.xml
@@ -3,11 +3,13 @@
      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <!-- Define ourselves -->
   <groupId>com.ge.research.sadl</groupId>
   <artifactId>com.ge.research.sadl.parent</artifactId>
   <version>3.5.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
+  <!-- Build ourselves -->
   <modules>
     <module>com.ge.research.jena</module>
     <module>com.ge.research.sadl</module>
@@ -40,9 +42,8 @@
     <module>com.ge.research.sadl.xtextgenerator</module>
   </modules>
 
-  <!-- Set properties for all modules -->
+  <!-- Set all properties in one place -->
   <properties>
-    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
@@ -50,14 +51,18 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <version.jena>3.17.0</version.jena>
+    <version.log4j>2.14.1</version.log4j>
     <version.mwe2>2.12.0</version.mwe2>
-    <version.sadl>3.5.0</version.sadl>
+    <version.sadl>${project.version}</version.sadl>
+    <version.slf4j>1.7.32</version.slf4j>
+    <version.surefire>3.0.0-M5</version.surefire>
     <version.tycho>2.4.0</version.tycho>
     <version.xtext>2.24.0</version.xtext>
     <version.xtext-antlr>2.1.1</version.xtext-antlr>
   </properties>
 
-  <!-- Set dependencies for all modules -->
+  <!-- Set all dependency versions in one place -->
   <dependencyManagement>
     <dependencies>
       <!-- Import Xtext dependencies from Xtext BOM -->
@@ -71,38 +76,38 @@
       <dependency>
         <groupId>com.ge.research.sadl</groupId>
         <artifactId>com.ge.research.jena</artifactId>
-        <version>${project.version}</version>
+        <version>${version.sadl}</version>
       </dependency>
       <dependency>
         <groupId>com.ge.research.sadl</groupId>
         <artifactId>com.ge.research.sadl</artifactId>
-        <version>${project.version}</version>
+        <version>${version.sadl}</version>
         <type>eclipse-plugin</type>
       </dependency>
       <dependency>
         <groupId>com.ge.research.sadl</groupId>
         <artifactId>com.ge.research.sadl.jena-wrapper-for-sadl</artifactId>
-        <version>${project.version}</version>
+        <version>${version.sadl}</version>
       </dependency>
       <dependency>
         <groupId>com.ge.research.sadl</groupId>
         <artifactId>reasoner-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.sadl}</version>
       </dependency>
       <dependency>
         <groupId>com.ge.research.sadl</groupId>
         <artifactId>reasoner-impl</artifactId>
-        <version>${project.version}</version>
+        <version>${version.sadl}</version>
       </dependency>
       <dependency>
         <groupId>com.ge.research.sadl</groupId>
         <artifactId>sadlserver-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.sadl}</version>
       </dependency>
       <dependency>
         <groupId>com.ge.research.sadl</groupId>
         <artifactId>sadlserver-impl</artifactId>
-        <version>${project.version}</version>
+        <version>${version.sadl}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.activation</groupId>
@@ -127,14 +132,8 @@
       <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>apache-jena-libs</artifactId>
-        <version>3.17.0</version>
+        <version>${version.jena}</version>
         <type>pom</type>
-        <exclusions>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.jena</groupId>
@@ -144,17 +143,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.14.1</version>
+        <version>${version.log4j}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.14.1</version>
+        <version>${version.log4j}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
-        <version>2.14.1</version>
+        <version>${version.log4j}</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -194,25 +193,19 @@
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${version.slf4j}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.32</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.32</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <version>1.7.32</version>
+        <version>${version.slf4j}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
 
   <build>
-    <finalName>${project.artifactId}-${version.sadl}.${maven.build.timestamp}</finalName>
-    <!-- Lock down plugins for consistent builds -->
+    <!-- Set all plugin versions in one place -->
     <pluginManagement>
       <plugins>
         <plugin>
@@ -266,6 +259,29 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.1.0</version>
+          <!-- Clean all files built by Tycho -->
+          <configuration>
+            <filesets>
+              <fileset>
+                <directory>${basedir}</directory>
+                <includes>
+                  <include>plugin.xml_gen</include>
+                </includes>
+              </fileset>
+              <fileset>
+                <directory>lib</directory>
+              </fileset>
+              <fileset>
+                <directory>model/generated</directory>
+              </fileset>
+              <fileset>
+                <directory>src-gen</directory>
+              </fileset>
+              <fileset>
+                <directory>xtend-gen</directory>
+              </fileset>
+            </filesets>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -310,7 +326,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>${version.surefire}</version>
           <configuration>
             <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
           </configuration>
@@ -370,7 +386,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>${version.surefire}</version>
           <configuration>
             <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
           </configuration>
@@ -380,6 +396,7 @@
           <artifactId>appassembler-maven-plugin</artifactId>
           <version>2.1.0</version>
         </plugin>
+        <!-- Define classpath and configuration needed to run Mwe2Launcher -->
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
@@ -388,7 +405,7 @@
             <dependency>
               <groupId>com.ge.research.sadl</groupId>
               <artifactId>com.ge.research.sadl.xtextgenerator</artifactId>
-              <version>${project.version}</version>
+              <version>${version.sadl}</version>
             </dependency>
             <dependency>
               <groupId>org.eclipse.emf</groupId>
@@ -427,6 +444,7 @@
             </execution>
           </executions>
         </plugin>
+        <!-- Goals: mvn -N versions:display-{dependency,plugin,property}-updates -->
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
@@ -456,9 +474,9 @@
             </environments>
             <target>
               <artifact>
-                <groupId>${project.groupId}</groupId>
+                <groupId>com.ge.research.sadl</groupId>
                 <artifactId>com.ge.research.sadl.target</artifactId>
-                <version>${project.version}</version>
+                <version>${version.sadl}</version>
               </artifact>
             </target>
           </configuration>
@@ -475,11 +493,26 @@
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-maven-plugin</artifactId>
           <version>${version.tycho}</version>
+          <extensions>true</extensions>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-p2-director-plugin</artifactId>
           <version>${version.tycho}</version>
+          <executions>
+            <execution>
+              <id>default-materialize-products</id>
+              <goals>
+                <goal>materialize-products</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>default-archive-products</id>
+              <goals>
+                <goal>archive-products</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
@@ -504,11 +537,18 @@
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-p2-repository-plugin</artifactId>
           <version>${version.tycho}</version>
+          <configuration>
+            <includeAllDependencies>true</includeAllDependencies>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-packaging-plugin</artifactId>
           <version>${version.tycho}</version>
+          <configuration>
+            <!-- Replace SNAPSHOT version when packaging the final product -->
+            <finalName>${project.artifactId}_${unqualifiedVersion}.${buildQualifier}</finalName>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
@@ -523,6 +563,9 @@
             </execution>
           </executions>
         </plugin>
+        <!-- To skip running (and compiling) tests, use: -Dmaven.test.skip
+             To skip tests, but still compile them, use: -DskipTests
+             To run all tests but only fail at end, use: -fae -->
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-surefire-plugin</artifactId>
@@ -547,9 +590,9 @@
               </goals>
             </execution>
             <execution>
-              <id>default-testCompile</id>
+              <id>default-xtend-install-debug-info</id>
               <goals>
-                <goal>testCompile</goal>
+                <goal>xtend-install-debug-info</goal>
               </goals>
             </execution>
           </executions>
@@ -563,33 +606,6 @@
         <groupId>com.github.ekryd.sortpom</groupId>
         <artifactId>sortpom-maven-plugin</artifactId>
       </plugin>
-      <!-- Clean additional files built by Tycho -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>${basedir}</directory>
-              <includes>
-                <include>plugin.xml_gen</include>
-              </includes>
-            </fileset>
-            <fileset>
-              <directory>lib</directory>
-            </fileset>
-            <fileset>
-              <directory>model/generated</directory>
-            </fileset>
-            <fileset>
-              <directory>src-gen</directory>
-            </fileset>
-            <fileset>
-              <directory>xtend-gen</directory>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
       <!-- Enforce Maven version -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -600,11 +616,10 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
       </plugin>
-      <!-- Build OSGI bundles -->
+      <!-- Build Eclipse bundles with Tycho -->
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-maven-plugin</artifactId>
-        <extensions>true</extensions>
       </plugin>
       <!-- Run Eclipse plugin tests with Tycho -->
       <plugin>


### PR DESCRIPTION
Make some cleanups including removing the slf4j-log4j12 jar since we
already have the log4j-slf4j-impl jar, making all manifests'
Bundle-Name match their Bundle-SymbolicName, saving the workspace when
ExecuteCommand finishes, removing extraneous Bundle-ClassPath, etc.

com.ge.research.jena/META-INF/MANIFEST.MF: Fix Bundle-Name.

ExecuteCommand.java: Save workspace before exiting.

com.ge.research.sadl.errorgenerator/META-INF/MANIFEST.MF: Fix
Bundle-Name.

com.ge.research.sadl.externalmodels/META-INF/MANIFEST.MF: Fix
Bundle-Name.

com.ge.research.sadl.ide/pom.xml: Remove slf4j-log4j12 jar.

com.ge.research.sadl.jena-wrapper-for-sadl/META-INF/MANIFEST.MF: Fix
Bundle-Name and Automatic-Module-Name, remove Bundle-ClassPath.

com.ge.research.sadl.jena/META-INF/MANIFEST.MF: Fix Bundle-Name.

com.ge.research.sadl.jena/pom.xml: Move dependency needed by
eu.somatik.serviceloader-maven-plugin to plugin itself.

com.ge.research.sadl.perspective/META-INF/MANIFEST.MF: Fix
Bundle-Name.

com.ge.research.sadl.swi-prolog-plugin/META-INF/MANIFEST.MF: Fix
Bundle-Name, remove Bundle-ClassPath.

com.ge.research.sadl.tests/pom.xml: Tweak comments, get surefire
version from parent pom.

com.ge.research.sadl.ui.tests/pom.xml: Remove unneeded failIfNoTests.

com.ge.research.sadl.xtextgenerator/META-INF/MANIFEST.MF: Fix
Bundle-Name.

com.ge.research.sadl.parent/pom.xml: Add comments, add more version
properties and use them where necessary, remove unnecessary exclusion,
add jcl-over-slf4j to managed dependencies and remove slf4j-log4j12,
configure some plugins better.