### PR TITLE
Differentiating restrictions, default value with and without domain specification for property.

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/SADL.xtext
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/SADL.xtext
@@ -188,7 +188,7 @@ SadlPropertyDeclarationInClass returns SadlProperty:
 
 SadlPropertyRestriction :
     	SadlCondition
-    |   {SadlTypeAssociation} ('describes'|'of') domain=SadlTypeReference
+    |   {SadlTypeAssociation} dmnkw=('describes'|'of') domain=SadlTypeReference
     |   {SadlRangeRestriction} ('has'|'with') ('a' singleValued?='single' 'value'|'values') 'of' 'type' ((typeonly=('class'|'data')) | range=SadlPrimaryTypeReference facet=SadlDataTypeFacet?)
     |   {SadlIsInverseOf}	'is' 'the' 'inverse' 'of' otherProperty=[SadlResource|QNAME]
     |   {SadlIsTransitive} 'is' 'transitive'


### PR DESCRIPTION
Added keyword to differentiate 'prop of class' from 'prop describes class'; the second only adds a domain class to the property. Full set of test cases to handle various combinations. Fix to issue #777 .