### PR TITLE
Stop building WebSADL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,12 +13,6 @@ updates:
     schedule:
       interval: "daily"
 
-  - package-ecosystem: "docker"
-    # Location of Dockerfile
-    directory: "/sadl3/com.ge.research.sadl.parent/theia-sadl-extension/apps/browser-app/"
-    schedule:
-      interval: "daily"
-
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     # Location of .github/workflows
@@ -32,12 +26,3 @@ updates:
     directory: "/sadl3/com.ge.research.sadl.parent/"
     schedule:
       interval: "daily"
-
-  # Maintain dependencies for Yarn
-  - package-ecosystem: "npm"
-    # Location of package manifests
-    directory: "/sadl3/com.ge.research.sadl.parent/theia-sadl-extension/"
-    schedule:
-      interval: "daily"
-    # Increase default limit of 5
-    open-pull-requests-limit: 25

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,10 +11,9 @@ on:
 # Runs a build job as a CI check:
 # - Builds SADL source & runs unit tests
 # - Builds SADL-Eclipse Docker image
-# - Builds WebSADL extension
 
 jobs:
-  build:
+  integration:
     strategy:
       matrix:
         distribution: [ temurin ]
@@ -46,22 +45,3 @@ jobs:
         file: sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.product/Dockerfile
         push: false
         tags: sadl/sadl-eclipse:ci
-
-    - name: Set up Node.js 10.x
-      uses: actions/setup-node@v2.4.1
-      with:
-        node-version: 10.19.0
-        registry-url: https://registry.npmjs.org
-        cache: 'yarn'
-        cache-dependency-path: '**/yarn.lock'
-
-    - name: Set up Python 2.7
-      uses: actions/setup-python@v2.2.2
-      with:
-        python-version: 2.7
-
-    - name: Build WebSADL extension
-      env:
-        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: yarn --cwd sadl3/com.ge.research.sadl.parent/theia-sadl-extension install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,14 +12,10 @@ on:
 # Runs a build job and uploads SADL build artifacts:
 # - Builds SADL source & runs unit tests
 # - Uploads SADL build artifacts to workflow
-# - Builds and pushes SADL-Eclipse Docker image
-# - Builds WebSADL extension
-# - Publishes WebSADL npm package
-# - Builds WebSADL Docker image
-# - Pushes WebSADL image to Docker Hub
+# - Builds SADL-Eclipse Docker image and pushes it
 
 jobs:
-  build:
+  main:
     strategy:
       matrix:
         distribution: [ temurin ]
@@ -31,8 +27,6 @@ jobs:
     steps:
     - name: Check out SADL source
       uses: actions/checkout@v2.3.5
-      with:
-        fetch-depth: 0 # Needed by lerna to publish canary versions
 
     - name: Set up Java
       uses: actions/setup-java@v2.3.1
@@ -69,44 +63,10 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Build and push SADL-Eclipse Docker image
+    - name: Build SADL-Eclipse Docker image and push it
       uses: docker/build-push-action@v2.7.0
       with:
         context: sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.product
         file: sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.product/Dockerfile
         push: true
         tags: sadl/sadl-eclipse:dev
-
-    - name: Set up Node.js 10.x
-      uses: actions/setup-node@v2.4.1
-      with:
-        node-version: 10.19.0
-        registry-url: https://registry.npmjs.org
-        cache: 'yarn'
-        cache-dependency-path: '**/yarn.lock'
-
-    - name: Set up Python 2.7
-      uses: actions/setup-python@v2.2.2
-      with:
-        python-version: 2.7
-
-    - name: Build WebSADL extension
-      env:
-        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: yarn --cwd sadl3/com.ge.research.sadl.parent/theia-sadl-extension install
-
-    - name: Publish WebSADL npm package
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      run: yarn --cwd sadl3/com.ge.research.sadl.parent/theia-sadl-extension run publish:next
-
-    - name: Build WebSADL Docker image
-      run: |
-        npm install --global node-gyp@6.0.1
-        npm config set node_gyp "`npm prefix -g`/lib/node_modules/node-gyp/bin/node-gyp.js"
-        echo "npm config get node_gyp -> `npm config get node_gyp`"
-        sadl3/com.ge.research.sadl.parent/theia-sadl-extension/scripts/build-docker.sh
-
-    - name: Push WebSADL image to Docker Hub
-      run: docker push theiaide/sadl:next

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 # Runs a build job and uploads SADL build artifacts:
 # - Builds SADL source & runs unit tests
 # - Uploads SADL build artifacts to release assets
-# - Builds and pushes SADL-Eclipse Docker image
+# - Builds SADL-Eclipse Docker image and pushes it
 
 jobs:
   release:
@@ -59,7 +59,7 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Build and push SADL-Eclipse Docker image
+    - name: Build SADL-Eclipse Docker image and push it
       uses: docker/build-push-action@v2.7.0
       with:
         context: sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.product


### PR DESCRIPTION
The WebSADL extension/Docker image is fragile and hard to build, which
makes it hard to maintain.  It also has next to no users, so we didn't
know that some functionality had stopped working since one year ago.
Now CI jobs cannot publish the WebSADL extension to the NPM registry
due to a versioning problem that's hard to fix.

This commit modifies GitHub Actions to stop building WebSADL to keep
CI jobs succeeding.  Note that we now build a new SADL-Eclipse Docker
image which also can generate OWL files from SADL files on the command
line.  Does anyone want to keep the WebSADL source and documentation
or should this pull request remove some files too?

dependabot.yml - Stop scanning WebSADL.

integration.yml, main.yml, release.yml - Stop building WebSADL.