### PR TITLE
Improve SADLCli build approach, fix caching and hanging

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/SADLCli.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/SADLCli.java
@@ -15,31 +15,30 @@ package com.ge.research.sadl.applications;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
+import java.util.Objects;
+import java.util.Set;
 
-import com.ge.research.sadl.preferences.SadlPreferences;
-import com.ge.research.sadl.processing.SadlConstants;
-import com.ge.research.sadl.utils.ResourceManager;
-import com.google.inject.Injector;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.filesystem.URIUtil;
+import org.eclipse.core.internal.resources.ICoreConstants;
+import org.eclipse.core.internal.resources.Workspace;
+import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
@@ -47,40 +46,33 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
 import org.eclipse.osgi.service.datalocation.Location;
-import org.eclipse.xtext.EcoreUtil2;
-import org.eclipse.xtext.generator.GeneratorContext;
-import org.eclipse.xtext.generator.GeneratorDelegate;
-import org.eclipse.xtext.generator.JavaIoFileSystemAccess;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
 import org.eclipse.xtext.preferences.PreferenceValuesByLanguage;
-import org.eclipse.xtext.resource.XtextResource;
-import org.eclipse.xtext.resource.XtextResourceSet;
-import org.eclipse.xtext.util.CancelIndicator;
-import org.eclipse.xtext.validation.CheckMode;
-import org.eclipse.xtext.validation.IResourceValidator;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
+import com.ge.research.sadl.preferences.SadlPreferences;
+import com.ge.research.sadl.utils.ResourceManager;
 
 /**
  * Builds SADL projects from the command line.
  *
  * You can use these command line arguments:
  *   - Configure SADL preferences              -config     {/path/to/file}
- *   - Import projects                         -import     {[uri:/]/path/to/project}
- *   - Import all projects in the tree         -importAll  {[uri:/]/path/to/projectTreeURI}
- *   - Build projects / the workspace          -build      {project_name_reg_ex | all}
- *   - Clean build projects / the workspace    -cleanBuild {project_name_reg_ex | all}
+ *   - Import a project                        -import     {[uri:/]/path/to/project}
+ *   - Import all projects in a tree           -importAll  {[uri:/]/path/to/projectTreeURI}
+ *   - Clean and build all imported projects   -cleanBuild
+ *   - Build all imported projects             -build
  *
  * Contains code copied from org.eclipse.cdt.managedbuilder.internal.core.HeadlessBuilder
  * https://git.eclipse.org/c/cdt/org.eclipse.cdt.git/tree/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/internal/core/HeadlessBuilder.java
@@ -89,62 +81,68 @@ import org.w3c.dom.NodeList;
 @SuppressWarnings("restriction")
 public class SADLCli implements IApplication {
 
+    /** Always print to original System.out despite any redirection */
+    private static final PrintStream OUT = System.out;
+    /** Always print to original System.err despite any redirection */
+    private static final PrintStream ERR = System.err;
+
     /**
      * Prints progress of tasks and subtasks
      */
-    protected static class PrintingProgressMonitor extends NullProgressMonitor {
+    private static class PrintingProgressMonitor extends NullProgressMonitor {
+        /**
+         * The progress monitor sometimes receives a subtask with the
+         * same name as the main task.  In the UI that change is not
+         * visible, but it is an extra line of output on the command
+         * line, so suppress that case.
+         */
+        private String last;
 
         @Override
         public void beginTask(String name, int totalWork) {
-            if (name != null && !name.isEmpty()) {
-                System.out.println(name);
-            }
+            subTask(name);
         }
 
         @Override
         public void subTask(String name) {
-            if (name != null && !name.isEmpty()) {
-                System.out.println(name);
+            if (name != null && !name.isEmpty() && !Objects.equals(last, name)) {
+                OUT.println(name);
             }
+            last = name;
         }
     }
 
     /** OK return status */
-    public static final Integer OK = IApplication.EXIT_OK;
+    private static final Integer OK = IApplication.EXIT_OK;
     /** Error return status */
-    public static final Integer ERROR = 1;
+    private static final Integer ERROR = 1;
     /** Show usage return status */
-    public static final Integer SHOW_USAGE = 2;
+    private static final Integer SHOW_USAGE = 2;
 
     /** SADL configuration file path */
-    protected String configFilePath = "SadlConfiguration.xml";
+    private String configFilePath = "SadlConfiguration.xml";
     /** SADL preferences */
-    protected PreferenceValuesByLanguage preferencesByLanguage = new PreferenceValuesByLanguage();
+    private PreferenceValuesByLanguage preferencesByLanguage = new PreferenceValuesByLanguage();
 
-    /** Project URIs / paths to import */
-    protected final Set<String> projectsToImport = new LinkedHashSet<>();
-    /** Trees of projects to recursively import */
-    protected final Set<String> projectTreeToImport = new LinkedHashSet<>();
-    /** Project names to clean */
-    protected final Set<String> projectRegExToClean = new LinkedHashSet<>();
-    /** Project names to build */
-    protected final Set<String> projectRegExToBuild = new LinkedHashSet<>();
-
-    /** Clean the workspace */
-    protected boolean cleanAll = false;
-    /** Build the workspace */
-    protected boolean buildAll = false;
+    /** User wants projects imported */
+    private final Set<String> projectsToImport = new LinkedHashSet<>();
+    /** User wants project trees imported recursively */
+    private final Set<String> projectTreesToImport = new LinkedHashSet<>();
+    /** User wants imported projects cleaned */
+    private boolean clean = false;
+    /** User wants imported projects built */
+    private boolean build = false;
 
     /**
-     * Verifies specified workspace is not already locked or in-use.
+     * Verifies workspace instance location is not already locked or in-use.
      *
      * @return true if a valid instance location has been set, false otherwise
      */
-    protected boolean checkInstanceLocation() {
+    private boolean checkInstanceLocation() {
         // -data @none was specified but an ide requires workspace
         Location instanceLoc = Platform.getInstanceLocation();
         if (instanceLoc == null || !instanceLoc.isSet()) {
-            System.err.println("Must specify a location for workspace, restart with -data switch");
+            ERR.println("Must specify a location for workspace, restart with -data switch");
             return false;
         }
 
@@ -152,12 +150,12 @@ public class SADLCli implements IApplication {
         try {
             // at this point its valid, so try to lock it to prevent concurrent use
             if (!instanceLoc.lock()) {
-                System.err.println("Workspace already in use");
+                ERR.println("Workspace already in use");
                 return false;
             }
             return true;
         } catch (IOException e) {
-            System.err.println("Couldn't obtain lock for workspace location");
+            ERR.println("Couldn't obtain lock for workspace location");
         }
         return false;
     }
@@ -168,15 +166,15 @@ public class SADLCli implements IApplication {
      * Arguments
      *   -config     {/path/to/file}
      *   -import     {[uri:/]/path/to/project}
-     *   -importAll  {[uri:/]/path/to/projectTreeURI} Import all projects in the tree
-     *   -build      {project_name_reg_ex | all}
-     *   -cleanBuild {project_name_reg_ex | all}
+     *   -importAll  {[uri:/]/path/to/projectTreeURI}
+     *   -cleanBuild
+     *   -build
      *
      * Each argument may be specified more than once
      * @param args String[] of arguments to parse
      * @return boolean indicating success
      */
-    protected boolean getArguments(String[] args) {
+    private boolean getArguments(String[] args) {
         try {
             if (args == null || args.length == 0) {
                 throw new Exception("No arguments specified");
@@ -187,42 +185,31 @@ public class SADLCli implements IApplication {
                 } else if ("-import".equals(args[i])) { //$NON-NLS-1$
                     projectsToImport.add(args[++i]);
                 } else if ("-importAll".equals(args[i])) { //$NON-NLS-1$
-                    projectTreeToImport.add(args[++i]);
-                } else if ("-build".equals(args[i])) { //$NON-NLS-1$
-                    projectRegExToBuild.add(args[++i]);
+                    projectTreesToImport.add(args[++i]);
                 } else if ("-cleanBuild".equals(args[i])) { //$NON-NLS-1$
-                    projectRegExToClean.add(args[++i]);
+                    clean = true;
+                    build = true;
+                } else if ("-build".equals(args[i])) { //$NON-NLS-1$
+                    build = true;
                 } else {
                     throw new Exception("Unknown argument: " + args[i]);
                 }
             }
         } catch (Exception e) {
-            System.err.println("Invalid arguments: " + Arrays.toString(args));
-            System.err.println("Error: " + e.getMessage());
+            ERR.println("Invalid arguments: " + Arrays.toString(args));
+            ERR.println("Error: " + e.getMessage());
             return false;
-        }
-
-        if (projectRegExToClean.contains("all") || projectRegExToClean.contains("*")) { //$NON-NLS-1$ //$NON-NLS-2$
-            cleanAll = true;
-            buildAll = true;
-            projectRegExToClean.remove("all"); //$NON-NLS-1$
-            projectRegExToClean.remove("*"); //$NON-NLS-1$
-        }
-        if (projectRegExToBuild.contains("all") || projectRegExToBuild.contains("*")) { //$NON-NLS-1$ //$NON-NLS-2$
-            buildAll = true;
-            projectRegExToBuild.remove("all"); //$NON-NLS-1$
-            projectRegExToBuild.remove("*"); //$NON-NLS-1$
         }
 
         return true;
     }
 
     /** Configures SADL preferences from SADL configuration file **/
-    protected boolean loadPreferences() {
+    private boolean loadPreferences() {
         // Check configuration file path
         File configFile = new File(configFilePath);
         if (!configFile.exists()) {
-            System.err.println("Configuration file: " + configFile + " does not exist");
+            ERR.println("Configuration file: " + configFile + " does not exist");
             return false;
         }
 
@@ -398,7 +385,7 @@ public class SADLCli implements IApplication {
                 }
             }
         } catch (Exception e) {
-            System.err.println("Error loading configuration file: " + e);
+            ERR.println("Error loading configuration file: " + e);
             return false;
         }
 
@@ -409,43 +396,14 @@ public class SADLCli implements IApplication {
         return true;
     }
 
-    /** Finds all projects matching specified regular expression */
-    protected boolean matchProjects(String projectRegEx, IProject[] projectList, Set<IProject> projects) {
-        boolean projectMatched = false;
-
-        // Find all projects that match the regular expression
-        try {
-            Pattern projectPattern = Pattern.compile(projectRegEx);
-
-            for (IProject project : projectList) {
-                Matcher projectMatcher = projectPattern.matcher(project.getName());
-
-                if (projectMatcher.matches()) {
-                    projectMatched = true;
-                    projects.add(project);
-                }
-            }
-            if (!projectMatched) {
-                System.err.println("WARNING: No projects matched '" + projectRegEx + "', skipping");
-            }
-        } catch (PatternSyntaxException e) {
-            System.err.println("Regular expression syntax error: " + e.toString());
-            System.err.println("Skipping '" + projectRegEx + "'");
-        }
-
-        return projectMatched;
-    }
-
     /**
      * Imports a project into the workspace
      * @param projURIStr base URI string
      * @param recurse Should we recurse down the URI importing all projects?
      * @return int OK / ERROR
      */
-    protected int importProject(String projURIStr, boolean recurse) throws CoreException, IOException {
-        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-        IProgressMonitor monitor = new PrintingProgressMonitor();
-
+    private int importProject(IWorkspace workspace, IProgressMonitor monitor, String projURIStr, 
+                              boolean recurse) throws CoreException, IOException {
         URI project_uri = null;
         try {
             project_uri = URI.create(projURIStr);
@@ -466,20 +424,20 @@ public class SADLCli implements IApplication {
                 project_uri = URIUtil.toURI(p);
             }
             if (project_uri.getScheme() == null) {
-                System.err.println("Invalid project URI: " + project_uri);
+                ERR.println("Invalid project URI: " + project_uri);
                 return ERROR;
             }
         }
 
         if (recurse) {
             if (!EFS.getStore(project_uri).fetchInfo().exists()) {
-                System.err.println("Directory: " + project_uri + " can't be found");
+                ERR.println("Directory: " + project_uri + " can't be found");
                 return ERROR;
             }
             for (IFileStore info : EFS.getStore(project_uri).childStores(EFS.NONE, monitor)) {
                 if (!info.fetchInfo().isDirectory())
                     continue;
-                int status = importProject(info.toURI().toString(), recurse);
+                int status = importProject(workspace, monitor, info.toURI().toString(), recurse);
                 if (status != OK)
                     return status;
             }
@@ -489,7 +447,7 @@ public class SADLCli implements IApplication {
         IFileStore fstore = EFS.getStore(project_uri).getChild(".project"); //$NON-NLS-1$
         if (!fstore.fetchInfo().exists()) {
             if (!recurse) {
-                System.err.println("Project: " + project_uri + " can't be found");
+                ERR.println("Project: " + project_uri + " can't be found");
                 return ERROR;
             }
             // .project not found; OK if we're recursing
@@ -497,9 +455,10 @@ public class SADLCli implements IApplication {
         }
 
         try (InputStream in = fstore.openInputStream(EFS.NONE, monitor)) {
-            IProjectDescription desc = root.getWorkspace().loadProjectDescription(in);
+            IProjectDescription desc = workspace.loadProjectDescription(in);
 
             // Check that a project with the same name doesn't already exist in the workspace
+            IWorkspaceRoot root = workspace.getRoot();
             IProject project = root.getProject(desc.getName());
             if (project.exists()) {
                 // It's ok if the project we're importing is the same as one already in the workspace
@@ -507,21 +466,21 @@ public class SADLCli implements IApplication {
                     project.open(monitor);
                     return OK;
                 }
-                System.err.println("Project: " + desc.getName() + " already exists in workspace");
+                ERR.println("Project: " + desc.getName() + " already exists in workspace");
                 return ERROR;
             }
             // Create and open the project
             // Note that if the project exists directly under the workspace root, we can't #setLocationURI(...)
             if (!URIUtil.equals(
-                    org.eclipse.core.runtime.URIUtil.append(ResourcesPlugin.getWorkspace().getRoot().getLocationURI(),
+                    org.eclipse.core.runtime.URIUtil.append(root.getLocationURI(),
                             org.eclipse.core.runtime.URIUtil.lastSegment(project_uri)),
                     project_uri))
                 desc.setLocationURI(project_uri);
             else
                 project_uri = null;
             // Check the URI is valid for a project in this workspace
-            if (!root.getWorkspace().validateProjectLocationURI(project, project_uri).equals(Status.OK_STATUS)) {
-                System.err.println("URI: " + project_uri + " is not valid in workspace");
+            if (!workspace.validateProjectLocationURI(project, project_uri).equals(Status.OK_STATUS)) {
+                ERR.println("URI: " + project_uri + " is not valid in workspace");
                 return ERROR;
             }
 
@@ -532,155 +491,84 @@ public class SADLCli implements IApplication {
         return OK;
     }
 
-    /** Builds specified projects */
-    protected boolean buildProjects(Set<IProject> projects, final XtextResourceSet resourceSet,
-            final IProgressMonitor monitor, final int buildType, Set<String> allBuildErrors) {
+    /** Cleans imported projects */
+    private void cleanProjects(IProject[] projects) {
+        // Don't delete files ending with ".rdf", ".xml", or ".yaml" in OwlModels
+        final String keepExtensions = ".*\\.(rdf|xml|yaml)";
+
+        for (IProject project : projects) {
+            // Find each project's OwlModels directory
+            URI projectURI = project.getLocationURI();
+            File projectDirectory = new File(projectURI.getSchemeSpecificPart());
+            File owlDirectory = new File(projectDirectory, ResourceManager.OWLDIR);
+
+            // Clean the OwlModels files since they will be regenerated automatically
+            OUT.println("Cleaning " + project.getName());
+            if (owlDirectory.exists() && owlDirectory.isDirectory()) {
+                for (File file : owlDirectory.listFiles()) {
+                    if (file.isFile() && !file.getName().matches(keepExtensions)) {
+                        if (file.delete()) OUT.println("Cleaning " + file);
+                    }
+                }
+            }
+        }
+    }
+
+    /** Builds imported projects */
+    private boolean buildProjects(IWorkspace iWorkspace, IProgressMonitor monitor, Set<String> allBuildErrors) {
         boolean buildSuccessful = true;
 
-        SubMonitor progress = SubMonitor.convert(monitor, 100).setWorkRemaining(projects.size());
-        for (IProject project : projects) {
-            buildSadlProject(project, resourceSet, progress.split(1), buildType);
-            buildSuccessful = buildSuccessful && isProjectSuccesfullyBuilt(project, resourceSet);
-            accumulateErrorMessages(project, resourceSet, allBuildErrors);
+        if (iWorkspace instanceof Workspace) {
+            Workspace workspace = (Workspace)iWorkspace;
+            IBuildConfiguration[] buildOrder = workspace.getBuildOrder();
+            int trigger = IncrementalProjectBuilder.FULL_BUILD;
+    
+            try {
+                IBuildConfiguration[] configs = ICoreConstants.EMPTY_BUILD_CONFIG_ARRAY;
+                IStatus result = workspace.getBuildManager().build(buildOrder, configs, trigger, monitor);
+                if (!result.isOK()) {
+                    buildSuccessful = false;
+                }
+            }
+            finally {
+                // Always send POST_BUILD if there was a PRE_BUILD
+                workspace.broadcastBuildEvent(workspace, IResourceChangeEvent.POST_BUILD, trigger);
+            }
+    
+            buildSuccessful = accumulateErrorMessages(buildOrder, buildSuccessful, allBuildErrors);
         }
 
         return buildSuccessful;
     }
 
-    /** Cleans implicit/owl files since they will be regenerated automatically */
-    private void cleanDirectory(File directory) {
-        // Keep only files ending with ".rdf", ".xml", or ".yaml"
-        final String keepExtensions = ".*\\.(rdf|xml|yaml)";
-        if (directory.exists() && directory.isDirectory()) {
-            for (File file : directory.listFiles()) {
-                if (file.isFile() && !file.getName().matches(keepExtensions)) {
-                    if (file.delete()) System.out.println("Cleaning " + file);
-                }
-            }
-        }
-    }
-
-    /** Finds all files having a given file extension */
-    private List<File> findFilesRecursively(File directory, String fileExtension, List<File> files) {
-        for (File file : directory.listFiles()) {
-            if (file.isDirectory()) {
-                findFilesRecursively(file, fileExtension, files);
-            } else if (file.isFile() && file.getName().endsWith(fileExtension)) {
-                files.add(file);
-            }
-        }
-        return files;
-    }
-
-    /** Writes a SADL resource as an OWL file */
-    private void writeAsOwl(Resource aResource, File owlDirectory) {
-        if (aResource instanceof XtextResource) {
-            XtextResource resource = (XtextResource)aResource;
-            System.out.println("Building " + resource.getURI().path());
-
-            // Generate the OWL file
-            GeneratorDelegate generator = resource.getResourceServiceProvider().get(GeneratorDelegate.class);
-            JavaIoFileSystemAccess access = resource.getResourceServiceProvider().get(JavaIoFileSystemAccess.class);
-            GeneratorContext context = new GeneratorContext();
-            context.setCancelIndicator(CancelIndicator.NullImpl);
-            access.setOutputPath(owlDirectory.getAbsolutePath());
-            generator.generate(resource, access, context);
-        }
-    }
-
-    /** Builds a SADL project */
-    protected void buildSadlProject(IProject project, final XtextResourceSet resourceSet,
-                                    final IProgressMonitor monitor, final int buildType) {
-        URI projectURI = project.getLocationURI();
-        File projectDirectory = new File(projectURI.getSchemeSpecificPart());
-        File implicitModelDirectory = new File(projectDirectory, SadlConstants.SADL_IMPLICIT_MODEL_FOLDER);
-        File owlDirectory = new File(projectDirectory, ResourceManager.OWLDIR);
-
-        if (buildType == IncrementalProjectBuilder.CLEAN_BUILD) {
-            // Clean implicit/owl model files since they will be regenerated automatically
-            System.out.println("Cleaning " + project.getName());
-            cleanDirectory(implicitModelDirectory);
-            cleanDirectory(owlDirectory);
-        } else if (buildType == IncrementalProjectBuilder.INCREMENTAL_BUILD) {
-            // Add SADL files to resource set and resolve interdependencies during first pass
-            List<File> sadlFiles = findFilesRecursively(projectDirectory, ".sadl", new ArrayList<>());
-            for (File file : sadlFiles) {
-                org.eclipse.emf.common.util.URI uri = 
-                    org.eclipse.emf.common.util.URI.createFileURI(file.getAbsolutePath());
-                Resource resource = resourceSet.getResource(uri, true);
-                IResourceValidator validator = ((XtextResource)resource).getResourceServiceProvider().getResourceValidator();
-                validator.validate(resource, CheckMode.NORMAL_AND_FAST, CancelIndicator.NullImpl);
-            }
-            EcoreUtil2.resolveAll(resourceSet);
-        } else if (buildType == IncrementalProjectBuilder.FULL_BUILD) {
-            // Generate OWL files from the SADL files during second pass
-            System.out.println("Building " + project.getName());
-            List<File> sadlFiles = findFilesRecursively(projectDirectory, ".sadl", new ArrayList<>());
-            for (File file : sadlFiles) {
-                org.eclipse.emf.common.util.URI uri = 
-                    org.eclipse.emf.common.util.URI.createFileURI(file.getAbsolutePath());
-                Resource resource = resourceSet.getResource(uri, true);
-                IResourceValidator validator = ((XtextResource)resource).getResourceServiceProvider().getResourceValidator();
-                validator.validate(resource, CheckMode.NORMAL_AND_FAST, CancelIndicator.NullImpl);
-                writeAsOwl(resource, owlDirectory);
-            }
-        }
-    }
-
-    /** Checks whether project was successfully built */
-    protected boolean isProjectSuccesfullyBuilt(IProject project, XtextResourceSet resourceSet) {
-        boolean noErrors = true;
-
-        // Check for error markers
+    /** Accumulates error messages after building imported projects */
+    private boolean accumulateErrorMessages(IBuildConfiguration[] buildOrder, boolean buildSuccessful, 
+                                           Set<String> allBuildErrors) {
+        // Get any error markers
         try {
-            int maxProblemSeverity = project.findMaxProblemSeverity(null, true, IResource.DEPTH_INFINITE);
-            noErrors = maxProblemSeverity < IMarker.SEVERITY_ERROR;
-        } catch (CoreException e) {
-            System.err.println("Error finding error markers in project: " + e);
-        }
-
-        // Check for resource errors
-        for (Resource resource : resourceSet.getResources()) {
-            noErrors = noErrors && resource.getErrors().isEmpty();
-        }
-
-        return noErrors;
-    }
-
-    /** Accumulates error messages after building project */
-    protected void accumulateErrorMessages(IProject project, XtextResourceSet resourceSet, Set<String> allBuildErrors) {
-        // Get error markers
-        try {
-            IMarker[] findMarkers = project.findMarkers(null, true, IResource.DEPTH_INFINITE);
-            for (IMarker marker : findMarkers) {
-                int severity = marker.getAttribute(IMarker.SEVERITY, IMarker.SEVERITY_INFO);
-                if (severity >= IMarker.SEVERITY_ERROR) {
-                    allBuildErrors.add(marker.toString());
+            for (IBuildConfiguration bc : buildOrder) {
+                IProject project = bc.getProject();
+                IMarker[] findMarkers = project.findMarkers(null, true, IResource.DEPTH_INFINITE);
+                for (IMarker marker : findMarkers) {
+                    int severity = marker.getAttribute(IMarker.SEVERITY, IMarker.SEVERITY_INFO);
+                    if (severity >= IMarker.SEVERITY_ERROR) {
+                        buildSuccessful = false;
+                        allBuildErrors.add(marker.toString());
+                    }
                 }
             }
         } catch (CoreException e) {
-            System.err.println("Error getting error markers in project: " + e);
+            ERR.println("Error getting error markers: " + e);
         } 
 
-        // Get resource errors
-        StringBuilder sb = new StringBuilder();
-        for (Resource resource : resourceSet.getResources()) {
-            for (Resource.Diagnostic error : resource.getErrors()) {
-                sb.setLength(0);
-                sb.append(resource.getURI().path()).append(":");
-                sb.append(error.getLine()).append(":");
-                sb.append(error.getColumn()).append(": ");
-                sb.append(error.getMessage());
-                allBuildErrors.add(sb.toString());
-            }
-        }
+        return buildSuccessful;
     }
 
     // Builds SADL projects from command line
     @Override
     public Object start(IApplicationContext context) throws Exception {
         // Return whether projects were built successfully
-        boolean buildSuccessful = true;
+        boolean buildSuccessful = false;
         Set<String> allBuildErrors = new LinkedHashSet<>();
 
         // Suppress log4j initialization warning and debug logs
@@ -692,20 +580,22 @@ public class SADLCli implements IApplication {
             return ERROR;
 
         // Make sure workspace is saved after build
-        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-        IWorkspaceDescription desc = root.getWorkspace().getDescription();
-        final boolean isAutoBuilding = root.getWorkspace().isAutoBuilding();
+        IWorkspace workspace = ResourcesPlugin.getWorkspace();
+        IWorkspaceRoot root = workspace.getRoot();
+        IWorkspaceDescription desc = workspace.getDescription();
+        final boolean isAutoBuilding = workspace.isAutoBuilding();
         IProgressMonitor monitor = new PrintingProgressMonitor();
+
         try {
             // Check whether workspace can be read and written
             if (!root.isAccessible()) {
-                System.err.println("Workspace: " + root.getLocationURI().toString() + " is not accessible");
+                ERR.println("Workspace: " + root.getLocationURI().toString() + " is not accessible");
                 return ERROR;
             }
-
+            
             // Turn off workspace auto-build and refresh workspace
             desc.setAutoBuilding(false);
-            root.getWorkspace().setDescription(desc);
+            workspace.setDescription(desc);
             root.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 
             // Get user provided arguments
@@ -719,80 +609,54 @@ public class SADLCli implements IApplication {
             }
 
             // Import project trees
-            for (String projURIStr : projectTreeToImport) {
-                int status = importProject(projURIStr, true);
+            for (String projURIStr : projectTreesToImport) {
+                int status = importProject(workspace, monitor, projURIStr, true);
                 if (status != OK)
                     return status;
             }
 
             // Import single projects
             for (String projURIStr : projectsToImport) {
-                int status = importProject(projURIStr, false);
+                int status = importProject(workspace, monitor, projURIStr, false);
                 if (status != OK)
                     return status;
             }
 
-            // Create resource set to use when building projects
-            Injector injector = new SADLCliAppStandaloneSetup().createInjectorAndDoEMFRegistration();
-            XtextResourceSet resourceSet = injector.getInstance(XtextResourceSet.class);
-            IProject[] allProjects = root.getProjects();
-            Set<IProject> projectsToBuild = new LinkedHashSet<>();
-
-            // Find projects user wanted cleaned
-            if (cleanAll) {
-                System.out.println("Cleaning all projects...");
-
-                // Match all projects in workspace
-                matchProjects(".*", allProjects, projectsToBuild); //$NON-NLS-1$
-            } else {
-                // Match regular expressions against project names
-                for (String regEx : projectRegExToClean) {
-                    matchProjects(regEx, allProjects, projectsToBuild);
-                }
+            // Clean the projects if the user wanted them cleaned
+            if (clean) {
+                OUT.println("Cleaning all projects...");
+                IProject[] allProjects = root.getProjects();
+                cleanProjects(allProjects);
             }
 
-            // Clean projects
-            buildProjects(projectsToBuild, resourceSet, monitor, IncrementalProjectBuilder.CLEAN_BUILD, new LinkedHashSet<>());
-
-            // Find projects user wanted built
-            if (buildAll) {
-                System.out.println("Building all projects...");
-
-                // Match all projects in workspace
-                matchProjects(".*", allProjects, projectsToBuild); //$NON-NLS-1$
-            } else {
-                // Match regular expressions against project names
-                for (String regEx : projectRegExToBuild) {
-                    matchProjects(regEx, allProjects, projectsToBuild);
-                }
+            // Build the projects if the user wanted them built
+            if (build) {
+                OUT.println("Building all projects...");
+                buildSuccessful = buildProjects(workspace, monitor, allBuildErrors);
             }
-
-            // Build projects using two passes in order to resolve dependencies between projects
-            buildProjects(projectsToBuild, resourceSet, monitor, IncrementalProjectBuilder.INCREMENTAL_BUILD, new LinkedHashSet<>());
-            buildSuccessful = buildProjects(projectsToBuild, resourceSet, monitor, IncrementalProjectBuilder.FULL_BUILD, allBuildErrors);
         } finally {
+            if (buildSuccessful) {
+                OUT.println("Build completed successfully");
+            } else {
+                OUT.println("Build failed with " + allBuildErrors.size() + " errors");
+                for (String buildError : allBuildErrors) {
+                    ERR.println(buildError);
+                }
+                // Don't print "Eclipse:\nJVM terminated. Exit code=1" message
+                System.getProperties().put("eclipse.exitdata", "");
+            }
+    
             // Wait for any outstanding jobs to finish
-            while (!Job.getJobManager().isIdle()) {
+            if (!Job.getJobManager().isIdle()) {
                 Thread.sleep(10);
             }
 
             // Reset workspace auto-build preference
             desc.setAutoBuilding(isAutoBuilding);
-            root.getWorkspace().setDescription(desc);
+            workspace.setDescription(desc);
 
-            // Save modified workspace
-            root.getWorkspace().save(true, monitor);
-        }
-
-        if (buildSuccessful) {
-            System.out.println("Build completed successfully");
-        } else {
-            System.out.println("Build encountered " + allBuildErrors.size() + " errors");
-            for (String buildError : allBuildErrors) {
-                System.err.println(buildError);
-            }
-            // Don't print "Eclipse:\nJVM terminated. Exit code=1" message
-            System.getProperties().put("eclipse.exitdata", "");
+            // We sometimes hang if we save modified workspace, so just exit forcefully
+            System.exit(buildSuccessful ? OK : ERROR);
         }
 
         return buildSuccessful ? OK : ERROR;

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/SADLCliAppRuntimeModule.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/SADLCliAppRuntimeModule.java
@@ -27,6 +27,7 @@ import com.google.inject.ConfigurationException;
 import com.google.inject.Inject;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
@@ -37,8 +38,6 @@ import org.eclipse.xtext.builder.clustering.CurrentDescriptions;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.resource.containers.IAllContainersState.Provider;
 import org.eclipse.xtext.resource.containers.ResourceSetBasedAllContainersStateProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Customized SADL runtime module that contains a workaround for the
@@ -46,6 +45,11 @@ import org.slf4j.LoggerFactory;
  */
 @SuppressWarnings("restriction")
 public class SADLCliAppRuntimeModule extends SADLRuntimeModule {
+
+    /** Always print to original System.out despite any redirection */
+    private static final PrintStream OUT = System.out;
+    /** Always print to original System.err despite any redirection */
+    private static final PrintStream ERR = System.err;
 
     @Override
     public Class<? extends Provider> bindIAllContainersState$Provider() {
@@ -73,22 +77,21 @@ public class SADLCliAppRuntimeModule extends SADLRuntimeModule {
     }
 
     public static class MySadlConsole implements SadlConsole {
-        private static final Logger LOGGER = LoggerFactory.getLogger(MySadlConsole.class);
 
         @Override
         public void print(final MessageManager.MessageType type, final String message) {
             switch (type) {
                 case ERROR:
-                    LOGGER.error(message);
+                    ERR.println("ERROR " + message);
                     break;
                 case WARN:
-                    LOGGER.warn(message);
+                    ERR.println("WARN  " + message);
                     break;
                 case INFO:
-                    LOGGER.info(message);
+                    OUT.println("INFO  " + message);
                     break;
                 default:
-                    LOGGER.debug(message);
+                    OUT.println("DEBUG " + message);
                     break;
             }
         }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.product/Dockerfile
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.product/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILDKIT_INLINE_CACHE=1
 
 # Base our image on Ubuntu 20.04 with latest Temurin JDK 11 build
 
-FROM eclipse-temurin:11.0.12_7-jdk-focal
+FROM eclipse-temurin:11.0.13_8-jdk-focal
 
 # Install packages needed to run SADL
 


### PR DESCRIPTION
Fix three SADLCli problems - building projects with dependencies,
taking a long time to translate LM.sadl, and sometimes hanging when
trying to exit.

SADLCli.java - Make -cleanBuild and -build options no longer take
arguments specifying projects.  Now SADLCli cleans and builds, or
builds, all imported projects at once.  Capture original System.out
and System.err in OUT and ERR and print to OUT and ERR to keep printed
output visible despite any redirection.  Make PrintingProgressMonitor
drop duplicated lines of output.  Change all "protected" to "private"
for better compilation warnings.  Remove fields, methods, and code for
specifying individual projects to clean or build since we now build
all imported projects.  Replace old clean and build methods with new
clean and build methods (leave ImplicitModel alone, clean only
OwlModels, move Cli-Andy code from start method to new build method).
Can't pass XtextResourceSet to accumulateErrorMessages to look for
errors anymore since new build code doesn't have any XtextResourceSet
Simplify start method (only one monitor used everywhere, new build
code moved to its own build method, fewer lines needed to clean and
build projects).  Prevent hanging by 1) changing while loop to if
statement in case another job won't stop running; 2) skipping calling
workspace.save which somtimes hangs; and 3) exiting forcefully by
calling System.exit since eclipse's shutdown process sometimes hangs.

SADLCliAppRuntimeModule.java - Stop using LOGGER, capture original
System.out and System.err in OUT and ERR, and print to OUT and ERR to
keep printed output visible despite any redirection or any problem
configuring logging.  However, MySadlConsole doesn't seem to be
actually used since I don't see any ERROR, WARN, INFO, or DEBUG
keywords in SADLCli's output.

Dockerfile - Bump eclipse-temurin from 11.0.12_7-jdk-focal to
11.0.13_8-jdk-focal.

DeclarationExtensions.xtend - Add caching of OntConceptType by
SadlResource, but use cache only if eclipse application is
com.ge.research.sadl.applications.SADLCli instead of the IDE.  Should
allow cache code to be merged into development branch without having
to identify IDE use cases under which cache should be cleared.