### PR TITLE
removing conditionnal from caching of DeclarationExtensions.getOntCon…

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
@@ -10726,7 +10726,16 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 		List<RDFNode> nodevals = new ArrayList<RDFNode>();
 		for (int i = 0; i < values.size(); i++) {
 			SadlExplicitValue value = values.get(i);
-			RDFNode nodeval = sadlExplicitValueToRdfNode(value, null, true);
+			if (value instanceof SadlResource) {
+				try {
+					OntConceptType vtype = getDeclarationExtensions().getOntConceptType((SadlResource)value);
+					if (!vtype.equals(OntConceptType.INSTANCE)) {
+						addError("Expected an instance in the enumeration of the class", value);
+					}
+				} catch (CircularDefinitionException e) {
+					throw new JenaProcessorException("Unexpected error, please report: " + e.getMessage());
+				}
+			}			RDFNode nodeval = sadlExplicitValueToRdfNode(value, null, true);
 			if (nodeval.canAs(Individual.class)) {
 				nodevals.add(nodeval.as(Individual.class));
 			} else {

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
@@ -10735,7 +10735,8 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 				} catch (CircularDefinitionException e) {
 					throw new JenaProcessorException("Unexpected error, please report: " + e.getMessage());
 				}
-			}			RDFNode nodeval = sadlExplicitValueToRdfNode(value, null, true);
+			}
+			RDFNode nodeval = sadlExplicitValueToRdfNode(value, null, true);
 			if (nodeval.canAs(Individual.class)) {
 				nodevals.add(nodeval.as(Individual.class));
 			} else {

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/model/SadlModelProcessorTypeCheckingTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/model/SadlModelProcessorTypeCheckingTest.xtend
@@ -542,11 +542,10 @@ class SadlModelProcessorTypeCheckingTest extends AbstractSADLModelProcessorTest 
 		for (issue : issues) {
 			println(issue.message)
 		}
-		// expect error on last line as i5 could be a C
-//		sadlModel.assertError("TypeCheckInfo(B (List), type of an unnamed typed list class, range of property p), cannot be compared (is) with TypeCheckInfo(the List [TypeCheckInfo(i5 (type B or C)].")
-	}
+		assertTrue(issues.isEmpty)
+	}	
 	
-		@Test
+	@Test
 	def void testTypedList_12() {
 		val sadlModel0 = '''
 		 uri "http://sadl.org/Model.sadl".
@@ -584,10 +583,13 @@ class SadlModelProcessorTypeCheckingTest extends AbstractSADLModelProcessorTest 
 		for (issue : issues) {
 			println(issue.message)
 		}
-		// expect error on last line as i5 could be a C
-//		sadlModel.assertError("TypeCheckInfo(B (List), type of an unnamed typed list class, range of property p), cannot be compared (is) with TypeCheckInfo(the List [TypeCheckInfo(i5 (type B or C)].")
+		assertTrue(issues.size == 4) {
+			for (issue : issues) {
+				assertTrue(issue.message.contains("class of intersection is a subclass of"))
+			}
+		}
 	}
-	
+		
 	@Test
 	def void testFirstElement_01() {
 		'''

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/model/DeclarationExtensions.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/model/DeclarationExtensions.xtend
@@ -249,11 +249,9 @@ class DeclarationExtensions {
 	ThreadLocal<Set<SadlResource>> recursionDetection = new ThreadLocal<Set<SadlResource>>();
 	
 	def OntConceptType getOntConceptType(SadlResource resource) throws CircularDefinitionException {
-		val sadlcli = "com.ge.research.sadl.applications.SADLCli".equals(System.getProperty("eclipse.application"))
-		if (sadlcli && cache.containsKey(resource)) {
+		if (cache.containsKey(resource)) {
 			return cache.get(resource)
-		}
-		
+		}		
 		if (resource.isExternal) {
 			val exttype = resource.getExternalResourceAdapter.type
 			return cacheOntConceptType(resource, exttype)


### PR DESCRIPTION
@tuxji , I've convinced myself that the caching in DeclarationExtensions.getOntConceptType do not pose an issue for the IDE. While on small test projects, the difference in IDE build performance with and without caching isn't large (on a build of 48 projects in the IDE, the difference seemed inconsequential), the difference on the RACK ontologies does seem significant (on the 11 RACK ontologies the time went from ~22 sec without caching to ~5 seconds with caching). So this PR removes the extra conditional on caching.

It also includes the changes I thought were merged into development from GH-823. When I followed your instructions it told me that a merge had been done and branch GH-823 could be deleted. However, my local git repo showed the remote not having those changes. So they are now in branch GH-819 and ready to be merged with this PR.