### PR TITLE
Bump Jena libs from 3.17.0 to 4.3.2

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/ge/research/sadl/jena/importer/CsvImporter.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/ge/research/sadl/jena/importer/CsvImporter.java
@@ -73,7 +73,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFWriterI;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
@@ -2084,7 +2084,7 @@ public class CsvImporter implements ITabularDataImporter {
 				}
 
 				try {
-					RDFWriter rdfw = getOwlModel().getWriter(format);
+					RDFWriterI rdfw = getOwlModel().getWriter(format);
 					// NTripleWriter.setProperty always throws UnknownPropertyException; ditto for N3.
 					if (format.startsWith("RDF/XML")) {
 						rdfw.setProperty("xmlbase", importModelNS); 

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/ge/research/sadl/jena/reasoner/JenaReasonerPlugin.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/ge/research/sadl/jena/reasoner/JenaReasonerPlugin.java
@@ -78,8 +78,8 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ModelGetter;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.RDFReader;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFReaderI;
+import org.apache.jena.rdf.model.RDFWriterI;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.rdf.model.Statement;
@@ -877,11 +877,11 @@ public class JenaReasonerPlugin extends Reasoner{
 			initializeDataModel();
 			OntModel newModel = ModelFactory.createOntologyModel(configurationMgr.getOntModelSpec(null));
 			if (format != null) {
-				RDFReader reader = newModel.getReader(format);
+				RDFReaderI reader = newModel.getReader(format);
 				reader.read(newModel, is, base);
 			}
 			else {
-				RDFReader reader = newModel.getReader();
+				RDFReaderI reader = newModel.getReader();
 				reader.read(newModel, is, base);
 			}
 			dataModel.add(newModel);
@@ -2870,7 +2870,7 @@ public class JenaReasonerPlugin extends Reasoner{
 			}
 			String format = SadlSerializationFormat.RDF_XML_ABBREV_FORMAT;	
 		    FileOutputStream fps = new FileOutputStream(filename);
-	        RDFWriter rdfw = m.getWriter(format);
+	        RDFWriterI rdfw = m.getWriter(format);
 	        rdfw.write(m, fps, modelname);
 	        try {
 				fps.close();
@@ -3608,7 +3608,7 @@ public class JenaReasonerPlugin extends Reasoner{
 	
 	private void dumpInfModel(String filename, Model m, String modelname, String format) throws FileNotFoundException {
 	    FileOutputStream fps = new FileOutputStream(filename);
-        RDFWriter rdfw = m.getWriter(format);
+        RDFWriterI rdfw = m.getWriter(format);
         rdfw.write(m, fps, modelname);
         try {
 			fps.close();

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemanticsllc/sadl/reasoner/JenaAugmentedReasonerPlugin.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/src/main/java/com/naturalsemanticsllc/sadl/reasoner/JenaAugmentedReasonerPlugin.java
@@ -44,7 +44,7 @@ import org.apache.jena.rdf.model.InfModel;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ModelGetter;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFWriterI;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.reasoner.Derivation;
 import org.apache.jena.reasoner.rulesys.GenericRuleReasoner;
@@ -417,7 +417,7 @@ public class JenaAugmentedReasonerPlugin extends JenaReasonerPlugin implements I
 		if (m != null) {
 			String format = SadlSerializationFormat.RDF_XML_ABBREV_FORMAT;	
 		    FileOutputStream fps = new FileOutputStream(filename);
-	        RDFWriter rdfw = m.getWriter(format);
+	        RDFWriterI rdfw = m.getWriter(format);
 	        rdfw.write(m, fps, modelname);
 	        try {
 				fps.close();

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena.sorted-owl-ntriples/src/main/java/com/ge/research/sadl/jena/SortedOwlNtriples.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena.sorted-owl-ntriples/src/main/java/com/ge/research/sadl/jena/SortedOwlNtriples.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFWriterI;
 
 public class SortedOwlNtriples {
 
@@ -52,7 +52,7 @@ public class SortedOwlNtriples {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		RDFWriter w = om.getWriter(N_TRIPLE_FORMAT);
+		RDFWriterI w = om.getWriter(N_TRIPLE_FORMAT);
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		w.write(om, out, format);
 		Charset charset = Charset.forName("UTF-8"); 

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/JenaBasedSadlModelProcessor.java
@@ -98,7 +98,7 @@ import org.apache.jena.rdf.model.NodeIterator;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFList;
 import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFWriterI;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
@@ -833,7 +833,7 @@ public class JenaBasedSadlModelProcessor extends SadlModelProcessor implements I
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		if (format.equals(SadlSerializationFormat.RDF_XML_FORMAT) || 
 				format.equals(SadlSerializationFormat.RDF_XML_ABBREV_FORMAT)) {
-			RDFWriter w2 = model.getWriter(format);
+			RDFWriterI w2 = model.getWriter(format);
 			w2.setProperty("xmlbase", modelName);
 			w2.write(model, out, modelName);
 		}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/MetricsProcessor.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/MetricsProcessor.java
@@ -23,7 +23,7 @@ import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.ontology.Ontology;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFWriterI;
 
 public class MetricsProcessor implements IMetricsProcessor {
 	private String filename;
@@ -104,7 +104,7 @@ public class MetricsProcessor implements IMetricsProcessor {
 	 */
 	@Override
 	public boolean saveMetrics(String format) throws IOException, ConfigurationException, URISyntaxException {
-		RDFWriter w = getTheJenaModel().getWriter(format);
+		RDFWriterI w = getTheJenaModel().getWriter(format);
 		w.setProperty("xmlbase", baseUri);
 		FileOutputStream out = new FileOutputStream(filename);
 		w.write(getTheJenaModel().getBaseModel(), out, baseUri);

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/inference/SadlJenaModelGetterPutter.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/src/com/ge/research/sadl/jena/inference/SadlJenaModelGetterPutter.java
@@ -31,7 +31,7 @@ import com.ge.research.sadl.reasoner.utils.SadlUtils;
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFWriterI;
 import org.apache.jena.tdb.TDB;
 import org.apache.jena.tdb.TDBFactory;
 
@@ -145,7 +145,7 @@ public class SadlJenaModelGetterPutter extends SadlJenaModelGetter {
     	}
     	else {
 			FileOutputStream fps = new FileOutputStream(owlFilename);
-			RDFWriter rdfw = m.getWriter(format);
+			RDFWriterI rdfw = m.getWriter(format);
 			// NTripleWriter.setProperty always throws UnknownPropertyException;
 			// ditto for N3.
 			if (format.startsWith("RDF/XML")) {

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-impl/src/main/java/com/ge/research/sadl/reasoner/ConfigurationManagerForEditing.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-impl/src/main/java/com/ge/research/sadl/reasoner/ConfigurationManagerForEditing.java
@@ -48,7 +48,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFWriterI;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Seq;
 import org.apache.jena.rdf.model.Statement;
@@ -1646,7 +1646,7 @@ public class ConfigurationManagerForEditing extends ConfigurationManager
 			}
 
 			try {
-				RDFWriter rdfw = model.getWriter(format);
+				RDFWriterI rdfw = model.getWriter(format);
 				// NTripleWriter.setProperty always throws UnknownPropertyException; ditto for N3.
 				if (format.startsWith("RDF/XML")) {
 //					rdfw.setProperty("xmlbase", toNamespace(modelName)); 

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-impl/src/main/java/com/ge/research/sadl/reasoner/SadlJenaModelGetterPutter.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-impl/src/main/java/com/ge/research/sadl/reasoner/SadlJenaModelGetterPutter.java
@@ -35,7 +35,7 @@ import com.ge.research.sadl.model.SadlSerializationFormat;
 import com.ge.research.sadl.reasoner.utils.SadlUtils;
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFWriterI;
 import org.apache.jena.tdb.TDB;
 import org.apache.jena.tdb.TDBFactory;
 
@@ -192,7 +192,7 @@ public class SadlJenaModelGetterPutter extends SadlJenaModelGetter {
 	 * @param os -- the OutputStream
 	 */
 	public void saveModel(Model m, String modelNamespace, String publicUri, String format, OutputStream os) {
-		RDFWriter rdfw = m.getWriter(format);
+		RDFWriterI rdfw = m.getWriter(format);
 		// NTripleWriter.setProperty always throws UnknownPropertyException;
 		// ditto for N3.
 		if (format.startsWith("RDF/XML")) {

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/com.ge.research.sadl.server.server-impl/src/main/java/com/ge/research/sadl/server/server/SadlServerPEImpl.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.server/com.ge.research.sadl.server.server-impl/src/main/java/com/ge/research/sadl/server/server/SadlServerPEImpl.java
@@ -79,8 +79,8 @@ import org.apache.jena.rdf.model.ModelGetter;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFList;
 import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.RDFReader;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFReaderI;
+import org.apache.jena.rdf.model.RDFWriterI;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
@@ -390,7 +390,7 @@ public class SadlServerPEImpl extends SadlServerImpl implements ISadlServerPE {
 			return addError(new ModelError("Failed to save model to file '" + fullyQualifiedOwlFilename + "': " + e.getLocalizedMessage(), ErrorType.ERROR));
 		}
 		try {
-		    RDFWriter rdfw = ontModel.getWriter(format);
+		    RDFWriterI rdfw = ontModel.getWriter(format);
 		    if (format.startsWith("RDF/XML")) {
 		        rdfw.setProperty("xmlbase", modelName); 
 		        rdfw.setProperty("relativeURIs", "");
@@ -1882,7 +1882,7 @@ public class SadlServerPEImpl extends SadlServerImpl implements ISadlServerPE {
 			boolean reasonerStat = reasoner.loadInstanceData(dataSrc.getInputStream(), inputFormat);
 			BufferedReader in = new BufferedReader(new InputStreamReader(dataSrc.getInputStream()));
 			String base = null;
-			RDFReader reader;
+			RDFReaderI reader;
 			try {
 				reader = getInstanceData().getReader();
 				reader.read(getInstanceData(), dataSrc.getInputStream(), base);

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/CustomSadlHooks.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/CustomSadlHooks.java
@@ -14,7 +14,7 @@ import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.ontology.Ontology;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFWriterI;
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IFile;
@@ -463,7 +463,7 @@ import com.google.inject.Inject;
 			String sadlMetricsMetadataModelName = SadlConstants.SADL_METRICS_METAMODEL_URI;;
 	
 			OntModel sadlMetricsMetamodel = getOntModelFromString(getSadlMetricsMetadataModel());
-			RDFWriter w = sadlMetricsMetamodel.getWriter(format);
+			RDFWriterI w = sadlMetricsMetamodel.getWriter(format);
 			w.setProperty("xmlbase", sadlMetricsMetadataModelName);
 			FileOutputStream out = new FileOutputStream(sadlMetricsMetadataFile);
 //						/****** temp *****/
@@ -496,7 +496,7 @@ import com.google.inject.Inject;
 				}
 				subMonitor.worked(1);
 			}
-			RDFWriter w3 = metricsModel.getWriter(format);
+			RDFWriterI w3 = metricsModel.getWriter(format);
 			w3.setProperty("xmlbase", modelName);
 			FileOutputStream out3 = new FileOutputStream(filename);
 			w3.write(metricsModel.getBaseModel(), out3, modelName);

--- a/sadl3/com.ge.research.sadl.parent/pom.xml
+++ b/sadl3/com.ge.research.sadl.parent/pom.xml
@@ -52,7 +52,7 @@
     <maven.compiler.target>8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <version.jena>3.17.0</version.jena>
+    <version.jena>4.3.2</version.jena>
     <version.log4j>2.17.1</version.log4j>
     <version.mwe2>2.12.0</version.mwe2>
     <version.sadl>${project.version}</version.sadl>
@@ -137,8 +137,33 @@
       </dependency>
       <dependency>
         <groupId>org.apache.jena</groupId>
-        <artifactId>jena-larq</artifactId>
-        <version>1.0.0-incubating</version>
+        <artifactId>jena-arq</artifactId>
+        <version>${version.jena}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-rdfconnection</artifactId>
+        <version>${version.jena}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-shacl</artifactId>
+        <version>${version.jena}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-shex</artifactId>
+        <version>${version.jena}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-tdb</artifactId>
+        <version>${version.jena}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-tdb2</artifactId>
+        <version>${version.jena}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Fix compilation problems with Jena 4.x by using renamed interfaces
RDFReaderI & RDFWriterI instead of original interfaces RDFReader &
RDFWriter.  SADL's performance with Jena 4.3.2 seems to be no worse
now (a prior attempt with Jena 4.1.0 used more memory and took over a
minute of a few seconds when running inference on STEM's Run.sadl).

Add each Jena library within apache-jena-libs to dependencyManagement
to ensure that any other dependencies which also bring in Jena
libraries will use the same Jena version instead of mixing Jena
versions.  Also remove jena-larq from dependencyManagement because
it's obsolete and unused.