### PR TITLE
Resolution of issue 957

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-api/src/main/java/com/ge/research/sadl/reasoner/utils/SadlUtils.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-api/src/main/java/com/ge/research/sadl/reasoner/utils/SadlUtils.java
@@ -21,12 +21,17 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import static java.nio.file.StandardOpenOption.*;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.StringTokenizer;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import jakarta.activation.DataSource;
 
@@ -1553,4 +1558,85 @@ public class SadlUtils {
 	    String s = String.format("%."+numSigFig+"G", BigDecimal.valueOf(val));
 	    return s;
 	}
+
+	/**
+	 * Method to determine if an executable file is on the path, that is can be found and executed.
+	 * @param exeFileName
+	 * @return
+	 */
+	public static boolean canExecute( final String exeFileName ) {
+		final String[] paths = System.getenv( "PATH" ).split( Pattern.quote( File.pathSeparator ) );
+		return Stream.of( paths ).map( Paths::get ).anyMatch(
+				path -> {
+					final Path p = path.resolve( exeFileName );
+					boolean found = false;
+
+					String[] EXTENSIONS;
+					if (isWindows()) {
+						EXTENSIONS = new String[] {"exe", "bat"};
+					}
+					else if (isMac()) {
+						EXTENSIONS = new String[] {""};
+					}
+					else if (isUnix()) {
+						EXTENSIONS = new String[] {""};
+					}
+					else {
+						String os = System.getProperty("os.name").toLowerCase();
+						System.err.println("Unsupported Operating System: " + os);
+						return false;
+					}
+					for( final String extension : EXTENSIONS ) {
+						String pathStr = p.toString() + extension;
+						Path ptt = Paths.get(pathStr);
+						if( java.nio.file.Files.isExecutable( ptt ) ) {
+							found = true;
+							break;
+						}
+					}
+
+					return found;
+				}
+				);
+	}
+
+	/**
+	 * Method to find the name of the operating system
+	 * @return
+	 */
+	public static String getOSIdent() {
+		return System.getProperty("os.name").toLowerCase();
+		
+	}
+	
+	/**
+	 * Method to determine if the OS is Windows
+	 * @return
+	 */
+	public static boolean isWindows() {
+
+		return (getOSIdent().indexOf("win") >= 0);
+
+	}
+
+	/**
+	 * Method to determine if the OS is Mac
+	 * @return
+	 */
+	public static boolean isMac() {
+
+		return (getOSIdent().indexOf("mac") >= 0);
+
+	}
+
+	/**
+	 * Method to determine if the OS is some flavor of Unix
+	 * @return
+	 */
+	public static boolean isUnix() {
+
+		return (getOSIdent().indexOf("nix") >= 0 || getOSIdent().indexOf("nux") >= 0 || getOSIdent().indexOf("aix") > 0 );
+		
+	}
+
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-api/src/test/java/com/ge/research/sadl/reasoner/utils/TestSadlUtils.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner/com.ge.research.sadl.reasoner-api/src/test/java/com/ge/research/sadl/reasoner/utils/TestSadlUtils.java
@@ -1,6 +1,9 @@
 package com.ge.research.sadl.reasoner.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 
 public class TestSadlUtils {
@@ -40,4 +43,17 @@ public class TestSadlUtils {
 		String numList = "[" + n1 + ", " + n2 + "," + n3 + " ," + n4 + " , " + n5 + "]";
 		assertEquals("[3.14, 0.0272, 3.14E-06, 3.14E+05, 314]", SadlUtils.formatNumberList(numList, 3));
 	}
+	
+	@Test
+	public void test_07() {
+		String testExe = "pwd";
+		assertTrue(SadlUtils.canExecute(testExe));
+	}
+	
+	@Test
+	public void test_08() {
+		String testExe = "paddywag";
+		assertFalse(SadlUtils.canExecute(testExe));
+	}
+
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.swi-prolog-plugin/src/main/java/com/ge/research/sadl/swi_prolog/reasoner/SWIPrologReasonerPlugin.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.swi-prolog-plugin/src/main/java/com/ge/research/sadl/swi_prolog/reasoner/SWIPrologReasonerPlugin.java
@@ -926,7 +926,7 @@ public class SWIPrologReasonerPlugin extends Reasoner {
 			String command = "swipl -f " +  runServiceFile; 
 			Runtime.getRuntime().exec(command); //for *NIX
 		} else {
-			throw new IOException("Unknown OS " + getOSIdent() + ", can't kill prolog service");
+			throw new IOException("Unknown OS " + getOSIdent() + ", can't start prolog service");
 		}
 	}
 

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.swi-prolog-plugin/src/test/java/com/ge/research/sadl/swi_prolog_reasoner/TestReasoner.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.swi-prolog-plugin/src/test/java/com/ge/research/sadl/swi_prolog_reasoner/TestReasoner.java
@@ -1,20 +1,19 @@
 package com.ge.research.sadl.swi_prolog_reasoner;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
-import com.ge.research.sadl.reasoner.BuiltinInfo;
 import com.ge.research.sadl.reasoner.ConfigurationException;
 import com.ge.research.sadl.reasoner.ConfigurationManager;
 import com.ge.research.sadl.reasoner.IConfigurationManager;
@@ -24,6 +23,7 @@ import com.ge.research.sadl.reasoner.QueryParseException;
 import com.ge.research.sadl.reasoner.ReasonerNotFoundException;
 import com.ge.research.sadl.reasoner.ResultSet;
 import com.ge.research.sadl.reasoner.TripleNotFoundException;
+import com.ge.research.sadl.reasoner.utils.SadlUtils;
 import com.ge.research.sadl.swi_prolog.reasoner.SWIPrologReasonerPlugin;
 
 public class TestReasoner {
@@ -52,6 +52,9 @@ public class TestReasoner {
 //	@Ignore
 	@Test
 	public void testInitializeReasoner() throws ReasonerNotFoundException, ConfigurationException, TripleNotFoundException {
+		if (!canRunSwiProlog()) {
+			return;
+		}
 		String kbIdentifier = kbroot + "/Shapes/OwlModels";
 		IConfigurationManager cm = new ConfigurationManager(kbIdentifier, null);
 		String prologReasonerClassName = "com.ge.research.sadl.swi_prolog.reasoner.SWIPrologReasonerPlugin";
@@ -69,6 +72,9 @@ public class TestReasoner {
 
 	@Test
 	public void testShapes01() throws ConfigurationException, ReasonerNotFoundException, IOException, TripleNotFoundException {
+		if (!canRunSwiProlog()) {
+			return;
+		}
 		String kbIdentifier = kbroot + "/Shapes/OwlModels";
 		IConfigurationManager cm = new ConfigurationManager(kbIdentifier, null);
 		String prologReasonerClassName = "com.ge.research.sadl.swi_prolog.reasoner.SWIPrologReasonerPlugin";
@@ -87,6 +93,9 @@ public class TestReasoner {
 
 	@Test
 	public void testGetPredicates() throws ConfigurationException, ReasonerNotFoundException, IOException, TripleNotFoundException, QueryParseException, QueryCancelledException {
+		if (!canRunSwiProlog()) {
+			return;
+		}
 		String kbIdentifier = kbroot + "/Shapes/OwlModels";
 		IConfigurationManager cm = new ConfigurationManager(kbIdentifier, null);
 		String prologReasonerClassName = "com.ge.research.sadl.swi_prolog.reasoner.SWIPrologReasonerPlugin";
@@ -163,4 +172,38 @@ public class TestReasoner {
 //			}
 //		}
 	}	
+
+
+	@Test
+	public void testCanExecuteSwiProlog() {
+		if (SadlUtils.isWindows()) {
+			boolean ce = SadlUtils.canExecute("swipl-win");
+			System.out.println("OS: Windows, SWI-Prolog installed: " + ce);
+		}
+		else if (SadlUtils.isMac()) {
+			boolean ce = SadlUtils.canExecute("swipl");
+			System.out.println("OS: Mac, SWI-Prolog installed: " + ce);
+		}
+		else if (SadlUtils.isUnix()) {
+			boolean ce = SadlUtils.canExecute("swipl");
+			System.out.println("OS: unix, SWI-Prolog installed: " + ce);
+		}
+	}
+		
+	private boolean canRunSwiProlog() {
+		boolean ce = false;
+		if (SadlUtils.isWindows()) {
+			ce = SadlUtils.canExecute("swipl-win");
+			System.out.println("OS: Windows, SWI-Prolog installed: " + ce);
+		}
+		else if (SadlUtils.isMac()) {
+			ce = SadlUtils.canExecute("swipl");
+			System.out.println("OS: Mac, SWI-Prolog installed: " + ce);
+		}
+		else if (SadlUtils.isUnix()) {
+			ce = SadlUtils.canExecute("swipl");
+			System.out.println("OS: unix, SWI-Prolog installed: " + ce);
+		}
+		return ce;
+	}
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: com.ge.research.sadl.ui,
  com.ge.research.jena,
  com.ge.research.sadl.tests,
  org.eclipse.ui.ide,
- org.eclipse.xtext.ui.testing
+ org.eclipse.xtext.ui.testing,
+ com.ge.research.sadl.swi-prolog-plugin;bundle-version="3.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: com.ge.research.sadl.ui.tests;x-internal=true,
  com.ge.research.sadl.ui.tests.contentassist

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/test/inference/AbstractSwiPrologTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/test/inference/AbstractSwiPrologTest.xtend
@@ -1,0 +1,63 @@
+package com.ge.research.sadl.ui.test.inference
+
+import com.ge.research.sadl.ui.tests.AbstractSadlPlatformTest
+import java.io.IOException
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
+import org.eclipse.xtext.ui.XtextProjectHelper
+import java.io.File
+import java.util.regex.Pattern
+import java.nio.file.Paths
+import java.util.stream.Stream
+import static java.nio.file.Files.isExecutable;
+import java.nio.file.Files
+import com.ge.research.sadl.reasoner.utils.SadlUtils
+
+abstract class AbstractSwiPrologTest extends AbstractSadlPlatformTest {
+
+static val CONFIG = '''
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns="http://com.ge.research.sadl.configuration#">
+  <Category rdf:about="http://com.ge.research.sadl.configuration#ReasonerSpec">
+    <reasonerClassName>com.ge.research.sadl.swi_prolog.reasoner.SWIPrologReasonerPlugin</reasonerClassName>
+  </Category>
+  <rdf:Description rdf:about="http://com.ge.research.sadl.configuration#SWI-Prolog-Reasoner">
+    <translatorClassName>com.ge.research.sadl.swi_prolog.translator.SWIPrologTranslatorPlugin</translatorClassName>
+  </rdf:Description>
+</rdf:RDF>
+	'''
+
+	override void createProject(String projectName) {
+		val project = IResourcesSetupUtil.createProject(projectName);
+		createFile('/OwlModels/configuration.rdf', CONFIG)
+		IResourcesSetupUtil.addNature(project, XtextProjectHelper.NATURE_ID);
+		IResourcesSetupUtil.addBuilder(project, XtextProjectHelper.BUILDER_ID);
+		IResourcesSetupUtil.waitForBuild;
+		configurePreferences();
+		// This is used to trigger the implicit model creation before the tests.
+		val file = createFile(project.name, 'Dummy.sadl', 'uri "http://sadl.org/Dummy.sadl."');
+		IResourcesSetupUtil.fullBuild();
+		file.delete(true, IResourcesSetupUtil.monitor);
+		IResourcesSetupUtil.fullBuild();
+		assertTrue('Dummy file should not exist.', !file.exists);
+	}
+	
+	def boolean canRunSwiProlog() {
+		var ce = false;
+		if (SadlUtils.isWindows()) {
+			ce = SadlUtils.canExecute("swipl-win");
+			System.out.println("OS: Windows, SWI-Prolog installed: " + ce);
+		}
+		else if (SadlUtils.isMac()) {
+			ce = SadlUtils.canExecute("swipl");
+			System.out.println("OS: Mac, SWI-Prolog installed: " + ce);
+		}
+		else if (SadlUtils.isUnix()) {
+			ce = SadlUtils.canExecute("swipl");
+			System.out.println("OS: unix, SWI-Prolog installed: " + ce);
+		}
+		return ce;
+	}
+	
+	
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/test/inference/AbstractSwiPrologTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/test/inference/AbstractSwiPrologTest.xtend
@@ -11,6 +11,7 @@ import java.util.stream.Stream
 import static java.nio.file.Files.isExecutable;
 import java.nio.file.Files
 import com.ge.research.sadl.reasoner.utils.SadlUtils
+import com.ge.research.sadl.jena.UtilsForJena
 
 abstract class AbstractSwiPrologTest extends AbstractSadlPlatformTest {
 
@@ -59,5 +60,12 @@ static val CONFIG = '''
 		return ce;
 	}
 	
-	
+	def String getPrologFileContent(String pfn) {
+		val projectPath = Paths.get(project.locationURI);
+		val modelFolderPath = projectPath.resolve(UtilsForJena.OWL_MODELS_FOLDER_NAME);
+		val su = new SadlUtils
+		val fn = su.fileUrlToFileName(modelFolderPath.toFile.absolutePath) + "/" + pfn
+		val content = su.fileToString(new File(fn))
+		return content
+	}
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/test/inference/TestSwiProlog.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/test/inference/TestSwiProlog.xtend
@@ -10,6 +10,8 @@ import com.ge.research.sadl.reasoner.utils.SadlUtils
 import java.io.File
 import com.ge.research.sadl.reasoner.SadlCommandResult
 import com.ge.research.sadl.reasoner.ResultSet
+import com.ge.research.sadl.preferences.SadlPreferences
+import org.eclipse.xtext.preferences.PreferenceKey
 
 class TestSwiProlog extends AbstractSwiPrologTest {
 
@@ -49,11 +51,7 @@ static val LIKES = '''
 		assertGeneratedOutputFor('Likes.sadl', OWL) [
 			println(it)
 		]
-		val projectPath = Paths.get(project.locationURI);
-		val modelFolderPath = projectPath.resolve(UtilsForJena.OWL_MODELS_FOLDER_NAME);
-		val su = new SadlUtils
-		val fn = su.fileUrlToFileName(modelFolderPath.toFile.absolutePath) + "/Likes.pl"
-		val content = su.fileToString(new File(fn))
+		val content = getPrologFileContent("Likes.pl")
 		println(content)
 		assertEquals(":- rdf_load('SadlBaseModel.owl').
 :- rdf_load('SadlImplicitModel.owl').
@@ -106,4 +104,181 @@ holds('http://sadl.org/test.sadl#likes', 'http://sadl.org/test.sadl#Sam', 'http:
 
 	}
 
+static val SHAPES = '''
+uri "http://sadl.org/Shapes/Shapes" alias shape. 
+
+Shape is a class described by area with values of type float.
+'''
+
+static val RECTANGLE = '''
+uri "http://sadl.org/Shapes/Rectangle" alias rect version "$Revision:$ Last modified on   $Date:$". 
+
+import "http://sadl.org/Shapes/Shapes". 
+
+Rectangle is a type of Shape,
+	described by height with values of type float,
+	described by width with values of type float.
+'''
+
+static val RULE1 = '''
+uri "http://sadl.org/Shapes/Rule" alias rule version "$Revision:$ Last modified on   $Date:$". 
+
+import "http://sadl.org/Shapes/Rectangle". 
+
+Rule AreaOfRect: if x is a Rectangle then area of x is height of x * width of x .
+
+«««Rule AreaOfRect2: then area of a Rectangle = height of the Rectangle * width of the Rectangle.
+'''
+
+static val RULE2 = '''
+uri "http://sadl.org/Shapes/Rule" alias rule version "$Revision:$ Last modified on   $Date:$". 
+
+import "http://sadl.org/Shapes/Rectangle". 
+
+«««Rule AreaOfRect: if x is a Rectangle then area of x is height of x * width of x .
+
+Rule AreaOfRect2: then area of a Rectangle = height of the Rectangle * width of the Rectangle.
+'''
+
+static val TEST = '''
+uri "http://sadl.org/Shapes/Test" alias test version "$Revision:$ Last modified on   $Date:$".
+
+import "http://sadl.org/Shapes/Rule". 
+
+MyRect is a Rectangle with height 2.5, with width 5.5.
+
+Test: area of MyRect is 13.75 .
+ 
+Ask: select ar where MyRect has area ar.
+'''
+
+	@Test
+	def void testShapes1() {
+		if (!canRunSwiProlog) {
+			return
+		}
+		val sfname = 'Shapes.sadl'
+		createFile(sfname, SHAPES)
+		assertNoErrorsInWorkspace;
+		assertGeneratedOutputFor('Shapes.sadl', OWL) [
+			println(it)
+		]
+		val rectfname = 'Rectangle.sadl'
+		createFile(rectfname, RECTANGLE)
+		assertNoErrorsInWorkspace;
+		assertGeneratedOutputFor('Rectangle.sadl', OWL) [
+			println(it)
+		]
+		val r1fname = 'Rule1.sadl'
+		createFile(r1fname, RULE1)
+		assertNoErrorsInWorkspace;
+		assertGeneratedOutputFor('Rule1.sadl', OWL) [
+			println(it)
+		]
+		val content = getPrologFileContent("Rule1.pl")
+		println(content)
+		assertEquals(":- rdf_load('SadlBaseModel.owl').
+:- rdf_load('SadlImplicitModel.owl').
+:- consult('SadlImplicitModel.pl').
+:- rdf_load('SadlBuiltinFunctions.owl').
+:- consult('SadlBuiltinFunctions.pl').
+:- rdf_load('Rectangle.owl').
+:- consult('Rectangle.pl').
+holds('http://sadl.org/Shapes/Shapes#area', PVx, PVv2) :- holds('http://www.w3.org/1999/02/22-rdf-syntax-ns#type', PVx, 'http://sadl.org/Shapes/Rectangle#Rectangle'), holds('http://sadl.org/Shapes/Rectangle#height', PVx, literal(type('http://www.w3.org/2001/XMLSchema#float',PV0))), atom_number(PV0,PVv0), holds('http://sadl.org/Shapes/Rectangle#width', PVx, literal(type('http://www.w3.org/2001/XMLSchema#float',PV1))), atom_number(PV1,PVv1), PVv2 is PVv0 * PVv1.
+".trim(),content.trim())
+		val testfname = 'Test.sadl'
+		createFile(testfname, TEST)
+		assertNoErrorsInWorkspace;
+		assertGeneratedOutputFor('Test.sadl', OWL) [
+			println(it)
+		]
+
+		assertInferencer(testfname, null, null) [
+			var idx = 0
+			for (scr : it) {
+				if (scr !== null) {
+					println(scr.toString)
+					if (scr instanceof SadlCommandResult) {
+						if (idx == 0) {
+							assertEquals("SADL Command Result:
+  rdf(test:MyRect, shape:area, 13.75)".trim, scr.toString.trim)
+						}
+						if (idx == 1) {
+							assertEquals("SADL Command Result:
+  select PVar where holds('http://sadl.org/Shapes/Shapes#area', 'http://sadl.org/Shapes/Test#MyRect', PVar)
+  \"PVar\"
+  \"13.75\"".trim, scr.toString.trim)
+						}
+						idx++
+					}
+				}
+			}
+		]
+	}
+	
+	@Test
+	def void testShapes2() {
+		if (!canRunSwiProlog) {
+			return
+		}
+		updatePreferences(new PreferenceKey(SadlPreferences.P_USE_ARTICLES_IN_VALIDATION.id, Boolean.TRUE.toString));
+		val sfname = 'Shapes.sadl'
+		createFile(sfname, SHAPES)
+		assertNoErrorsInWorkspace;
+		assertGeneratedOutputFor('Shapes.sadl', OWL) [
+			println(it)
+		]
+		val rectfname = 'Rectangle.sadl'
+		createFile(rectfname, RECTANGLE)
+		assertNoErrorsInWorkspace;
+		assertGeneratedOutputFor('Rectangle.sadl', OWL) [
+			println(it)
+		]
+		val r1fname = 'Rule2.sadl'
+		createFile(r1fname, RULE2)
+		assertNoErrorsInWorkspace;
+		assertGeneratedOutputFor('Rule2.sadl', OWL) [
+			println(it)
+		]
+		val content = getPrologFileContent("Rule2.pl")
+		println(content)
+		assertEquals(":- rdf_load('SadlBaseModel.owl').
+:- rdf_load('SadlImplicitModel.owl').
+:- consult('SadlImplicitModel.pl').
+:- rdf_load('SadlBuiltinFunctions.owl').
+:- consult('SadlBuiltinFunctions.pl').
+:- rdf_load('Rectangle.owl').
+:- consult('Rectangle.pl').
+holds('http://sadl.org/Shapes/Shapes#area', PVv0, PVv3) :- holds('http://www.w3.org/1999/02/22-rdf-syntax-ns#type', PVv0, 'http://sadl.org/Shapes/Rectangle#Rectangle'), holds('http://sadl.org/Shapes/Rectangle#height', PVv0, literal(type('http://www.w3.org/2001/XMLSchema#float',PV0))), atom_number(PV0,PVv1), holds('http://sadl.org/Shapes/Rectangle#width', PVv0, literal(type('http://www.w3.org/2001/XMLSchema#float',PV1))), atom_number(PV1,PVv2), PVv3 is PVv1 * PVv2.
+".trim(),content.trim())
+		val testfname = 'Test.sadl'
+		createFile(testfname, TEST)
+		assertNoErrorsInWorkspace;
+		assertGeneratedOutputFor('Test.sadl', OWL) [
+			println(it)
+		]
+
+		assertInferencer(testfname, null, null) [
+			var idx = 0
+			for (scr : it) {
+				if (scr !== null) {
+					println(scr.toString)
+					if (scr instanceof SadlCommandResult) {
+						if (idx == 0) {
+							assertEquals("SADL Command Result:
+  rdf(test:MyRect, shape:area, 13.75)".trim, scr.toString.trim)
+						}
+						if (idx == 1) {
+							assertEquals("SADL Command Result:
+  select PVar where holds('http://sadl.org/Shapes/Shapes#area', 'http://sadl.org/Shapes/Test#MyRect', PVar)
+  \"PVar\"
+  \"13.75\"".trim, scr.toString.trim)
+						}
+						idx++
+					}
+				}
+			}
+		]
+	}
+	
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/test/inference/TestSwiProlog.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/test/inference/TestSwiProlog.xtend
@@ -1,0 +1,109 @@
+package com.ge.research.sadl.ui.test.inference;
+
+import com.ge.research.sadl.ui.tests.AbstractSadlPlatformTest
+import org.junit.Test
+
+import static com.ge.research.sadl.ui.tests.GeneratedOutputFormat.*
+import java.nio.file.Paths
+import com.ge.research.sadl.jena.UtilsForJena
+import com.ge.research.sadl.reasoner.utils.SadlUtils
+import java.io.File
+import com.ge.research.sadl.reasoner.SadlCommandResult
+import com.ge.research.sadl.reasoner.ResultSet
+
+class TestSwiProlog extends AbstractSwiPrologTest {
+
+static val LIKES = '''
+		 uri "http://sadl.org/test.sadl" alias test.
+		 
+		 Person is a class described by likes with values of type Food.
+		 Food is a class.
+		 {indian, mild, chinese, italian} are types of Food.
+		 
+		 Sam is a Person.
+		 {dahl,  curry, tandoori, kurma} are instances of indian.
+		 {chop_suey, chow_mein, sweet_and_sour} are instances of chinese.
+		 {pizza, spagetti} are instances of italian.
+		 
+		 {dahl, tandoori, kurma} are instances of mild.
+		 
+		 chips is a Food.
+		 
+		 Rule R1: if x is a mild and x is a indian then Sam likes x.
+		 Rule R2: if x is a chinese then Sam likes x.
+		 Rule R3: if x is an italian then Sam likes x.
+		 Rule R4: if x is chips then Sam likes x. 
+		 
+		 Ask: select x where x is an indian and x is a mild.
+		 Ask: select x where Sam likes x.
+	'''
+	
+	@Test
+	def void testLikes() {
+		if (!canRunSwiProlog) {
+			return
+		}
+		val sfname = 'Likes.sadl'
+		createFile(sfname, LIKES)
+		assertNoErrorsInWorkspace;
+		assertGeneratedOutputFor('Likes.sadl', OWL) [
+			println(it)
+		]
+		val projectPath = Paths.get(project.locationURI);
+		val modelFolderPath = projectPath.resolve(UtilsForJena.OWL_MODELS_FOLDER_NAME);
+		val su = new SadlUtils
+		val fn = su.fileUrlToFileName(modelFolderPath.toFile.absolutePath) + "/Likes.pl"
+		val content = su.fileToString(new File(fn))
+		println(content)
+		assertEquals(":- rdf_load('SadlBaseModel.owl').
+:- rdf_load('SadlImplicitModel.owl').
+:- consult('SadlImplicitModel.pl').
+:- rdf_load('SadlBuiltinFunctions.owl').
+:- consult('SadlBuiltinFunctions.pl').
+holds('http://sadl.org/test.sadl#likes', 'http://sadl.org/test.sadl#Sam', PVx) :- holds('http://www.w3.org/1999/02/22-rdf-syntax-ns#type', PVx, 'http://sadl.org/test.sadl#mild'), holds('http://www.w3.org/1999/02/22-rdf-syntax-ns#type', PVx, 'http://sadl.org/test.sadl#indian').
+holds('http://sadl.org/test.sadl#likes', 'http://sadl.org/test.sadl#Sam', PVx) :- holds('http://www.w3.org/1999/02/22-rdf-syntax-ns#type', PVx, 'http://sadl.org/test.sadl#chinese').
+holds('http://sadl.org/test.sadl#likes', 'http://sadl.org/test.sadl#Sam', PVx) :- holds('http://www.w3.org/1999/02/22-rdf-syntax-ns#type', PVx, 'http://sadl.org/test.sadl#italian').
+holds('http://sadl.org/test.sadl#likes', 'http://sadl.org/test.sadl#Sam', 'http://sadl.org/test.sadl#chips').
+".trim(),content.trim())
+//		assertGeneratedOutputFor('Likes.sadl', PL) [
+//			println(it)
+//		]
+		assertInferencer(sfname, null, null) [
+			var idx = 0
+			for (scr : it) {
+				println(scr.toString)
+				assertTrue(scr instanceof SadlCommandResult)
+				val tr = (scr as SadlCommandResult).results
+				assertTrue(tr instanceof ResultSet)
+				if (idx == 0) {
+					assertEquals("SADL Command Result:
+  select PVx where holds('http://www.w3.org/1999/02/22-rdf-syntax-ns#type', PVx, 'http://sadl.org/test.sadl#indian'), holds('http://www.w3.org/1999/02/22-rdf-syntax-ns#type', PVx, 'http://sadl.org/test.sadl#mild')
+  \"PVx\"
+  \"http://sadl.org/test.sadl#tandoori\"
+  \"http://sadl.org/test.sadl#dahl\"
+  \"http://sadl.org/test.sadl#kurma\"
+".trim, scr.toString.trim)
+				}
+				if (idx == 1) {
+					assertEquals("SADL Command Result:
+  select PVx where holds('http://sadl.org/test.sadl#likes', 'http://sadl.org/test.sadl#Sam', PVx)
+  \"PVx\"
+  \"http://sadl.org/test.sadl#tandoori\"
+  \"http://sadl.org/test.sadl#dahl\"
+  \"http://sadl.org/test.sadl#kurma\"
+  \"http://sadl.org/test.sadl#sweet_and_sour\"
+  \"http://sadl.org/test.sadl#chow_mein\"
+  \"http://sadl.org/test.sadl#chop_suey\"
+  \"http://sadl.org/test.sadl#spagetti\"
+  \"http://sadl.org/test.sadl#pizza\"
+  \"http://sadl.org/test.sadl#chips\"
+".trim, scr.toString.trim)
+				}
+				idx++
+			}
+			assertTrue(idx > 0)
+		];
+
+	}
+
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/tests/GeneratedOutputFormat.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/tests/GeneratedOutputFormat.java
@@ -54,6 +54,18 @@ public enum GeneratedOutputFormat implements GeneratedOutputLocationProvider {
 			return OWLDIR + "/" + extractFileName(inputFilePath) + ".rules";
 		}
 
+	},
+
+	/**
+	 * The prolog rules output.
+	 */
+	PL {
+
+		@Override
+		public String get(String inputFilePath) {
+			return OWLDIR + "/" + extractFileName(inputFilePath) + ".pl";
+		}
+
 	};
 
 	protected String extractFileName(String inputFilePath) {


### PR DESCRIPTION
For some reason that I haven't been able to figure out AbstractSadlPlatformTest.assertGeneratedOutputFor doesn't work with the addition for Prolog files. The Prolog file, while present on-disc, is never added to the resource tree. The call in the build to refresh the resource tree doesn't happen I think.
There are now actual reasoning tests for the SWI-Prolog reasoner and a framework for adding more. The tests for SWI-Prolog reasoning are conditionals so that if SWI-Prolog isn't installed on the host development machine the test just returns before doing anything that would try to start SWI-Prolog. This is only tested on Linux as I don't have Windows and Mac development environments.
