### PR TITLE
Don't export org.slf4j anymore

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.jena/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.jena/META-INF/MANIFEST.MF
@@ -140,8 +140,7 @@ Export-Package: au.com.bytecode.opencsv,
  org.apache.jena.util,
  org.apache.jena.util.iterator,
  org.apache.jena.vocabulary,
- org.pojava.datetime,
- org.slf4j
+ org.pojava.datetime
 Bundle-ClassPath: lib/collection.jar,
  lib/commons-cli.jar,
  lib/commons-codec.jar,
@@ -181,7 +180,6 @@ Bundle-ClassPath: lib/collection.jar,
  lib/opencsv.jar,
  lib/reasoner-api.jar,
  lib/reasoner-impl.jar,
- lib/slf4j-api.jar,
  lib/stax-api.jar,
  lib/wstx-asl.jar
 Automatic-Module-Name: com.ge.research.jena

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.jena/build.properties
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.jena/build.properties
@@ -38,7 +38,6 @@ bin.includes = META-INF/,\
                lib/opencsv.jar,\
                lib/reasoner-api.jar,\
                lib/reasoner-impl.jar,\
-               lib/slf4j-api.jar,\
                lib/stax-api.jar,\
                lib/wstx-asl.jar,\
                log4j2.properties

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: com.ge.research.jena,
  org.eclipse.lsp4j.generator,
  org.eclipse.lsp4j.jsonrpc,
  org.eclipse.xtext.ide,
- org.eclipse.xtext.xbase.ide
+ org.eclipse.xtext.xbase.ide,
+ org.slf4j.api
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: com.ge.research.sadl.ide,
  com.ge.research.sadl.ide.contentassist.antlr,

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena-wrapper-for-sadl/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: com.ge.research.jena,
  com.ge.research.sadl.jena,
  org.eclipse.core.runtime,
  org.eclipse.osgi,
- org.junit;bundle-version="4.12.0";resolution:=optional
+ org.junit,
+ org.slf4j.api
 Eclipse-BuddyPolicy: dependent
 Eclipse-RegisterBuddy: com.ge.research.sadl
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.jena/META-INF/MANIFEST.MF
@@ -50,7 +50,8 @@ Require-Bundle: com.ge.research.jena,
  org.eclipse.emf.ecore,
  org.eclipse.equinox.common,
  org.eclipse.xtext,
- org.eclipse.xtext.builder
+ org.eclipse.xtext.builder,
+ org.slf4j.api
 Import-Package: jakarta.activation
 Eclipse-RegisterBuddy: com.ge.research.sadl
 Automatic-Module-Name: com.ge.research.sadl.jena

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.swi-prolog-plugin/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.swi-prolog-plugin/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: com.ge.research.jena,
  com.ge.research.sadl,
  org.eclipse.core.runtime,
  org.eclipse.osgi,
- org.junit;bundle-version="4.12.0";resolution:=optional
+ org.junit,
+ org.slf4j.api
 Eclipse-RegisterBuddy: com.ge.research.sadl
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.target/com.ge.research.sadl.target.target
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.target/com.ge.research.sadl.target.target
@@ -37,6 +37,7 @@
             <unit id="org.objectweb.asm" version="0.0.0"/>
             <unit id="org.objectweb.asm.tree" version="0.0.0"/>
             <unit id="org.opentest4j" version="0.0.0"/>
+            <unit id="org.slf4j.api" version="0.0.0"/>
             <repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
         </location>
     </locations>

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/META-INF/MANIFEST.MF
@@ -27,7 +27,8 @@ Require-Bundle: com.ge.research.jena,
  org.eclipse.xtext.ui,
  org.eclipse.xtext.ui.codetemplates.ui,
  org.eclipse.xtext.ui.shared,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+ org.slf4j.api
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: com.ge.research.sadl.ui,
  com.ge.research.sadl.ui.builder,

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: com.ge.research.jena,
  org.eclipse.xtext.xbase,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.jsoup,
- org.objectweb.asm;resolution:=optional
+ org.objectweb.asm;resolution:=optional,
+ org.slf4j.api
 Eclipse-BuddyPolicy: dependent
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: com.ge.research.sadl,


### PR DESCRIPTION
No SADL plugin should export the org.slf4j package.  Doing so prevents third party Eclipse plugins from requiring both SADL and org.slf4j.api bundles in their own Require-Bundles.  Make all SADL plugins import the org.slf4j package from the org.slf4j.api bundle as well.

com.ge.research.jena/META-INF/MANIFEST.MF: Remove org.slf4j from Export-Package.  Remove slf4j-api.jar from Bundle-ClassPath.

com.ge.research.jena/build.properties: Remove slf4j-api.jar from bin.includes.

com.ge.research.sadl.target.target: Get org.slf4.api bundle from ORBIT P2 repository.

com.ge.research.sadl.ide/META-INF/MANIFEST.MF,
com.ge.research.sadl.jena-wrapper-for-sadl/META-INF/MANIFEST.MF, com.ge.research.sadl.jena/META-INF/MANIFEST.MF,
com.ge.research.sadl.swi-prolog-plugin/META-INF/MANIFEST.MF, com.ge.research.sadl.ui/META-INF/MANIFEST.MF,
com.ge.research.sadl/META-INF/MANIFEST.MF,
: Add org.slf4j.api to Require-Bundle.